### PR TITLE
[Rogue-576]-Removed padding below senders name

### DIFF
--- a/Sources/Playbook/Message/PBMessage.swift
+++ b/Sources/Playbook/Message/PBMessage.swift
@@ -34,12 +34,12 @@ public struct PBMessage<Content: View, Avatar: View>: View {
                     }
                     if let timestamp = timestamp {
                         timestamp.padding(.leading, 8)
-                            .padding(.bottom, -4)
+                            .padding(.bottom,-4)
                     }
+
                 })
-                .padding(.bottom, -2)
+                .padding(.bottom,-10)
                 content
-                    .padding(.top, -2)
             })
         })
         .frame(minWidth: 0, maxWidth: .infinity, alignment: .topLeading)


### PR DESCRIPTION
the message content is below senders name

# What does this PR do?
This PR removes space from under a senders  name.
____

#### Screens
![Screenshot 2022-12-22 at 9 22 13 AM](https://user-images.githubusercontent.com/103598915/209154662-132a6bee-79c9-4b6e-893c-b02ea6bb5f22.png)

<img width="810" alt="Screenshot 2022-12-22 at 9 25 14 AM" src="https://user-images.githubusercontent.com/103598915/209155173-ac9f04be-f0c4-4c06-80e7-915fd95b79c9.png">


#### Breaking Changes
NO

#### How to test this

- Look at space between senders name and message content.
- There should be no space between senders name and message content.

#### Checklist:

- [`enhancement` / `improvement`] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new component`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.

'enhancement'
- [ ] **SCREENSHOT** Please add a screen shot or two.
