### PR TITLE
Fix kerning for caption typography

### DIFF
--- a/Sources/Playbook/Typography/Typography.swift
+++ b/Sources/Playbook/Typography/Typography.swift
@@ -47,6 +47,13 @@ public struct Typography: ViewModifier {
         }
     }
 
+    var kerning: CGFloat {
+        switch style {
+        case .caption:          return 1.12
+        default:                return 1
+        }
+    }
+
     var casing: Text.Case? {
         switch style {
         case .largeCaption, .caption: return .uppercase
@@ -61,6 +68,7 @@ public struct Typography: ViewModifier {
             .lineSpacing(spacing) // Only works between lines in a paragraph.
             .padding(.vertical, spacing) // Adds the space around the text block.
             .textCase(casing)
+            .kerning(kerning)
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

Changes kerning for typography of type caption, to match playbook web. Paired on this with Megan.

#### Screens

Before:
<img width="107" alt="image" src="https://user-images.githubusercontent.com/4157166/213528670-c1d4e989-2982-42ac-a089-662b83c4ebc6.png">
After:
<img width="121" alt="image" src="https://user-images.githubusercontent.com/4157166/213528596-654402ad-7ecb-4771-9e4b-f821d26a92b8.png">

#### Breaking Changes

This will affect all usages of caption.

#### How to test this

Visual check.

#### Checklist:

- [x] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new component`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [x] **SCREENSHOT** Please add a screen shot or two.
