### PR TITLE
Revert "Fix kerning for caption typography"

### DIFF
--- a/Sources/Playbook/Typography/Typography.swift
+++ b/Sources/Playbook/Typography/Typography.swift
@@ -47,13 +47,6 @@ public struct Typography: ViewModifier {
         }
     }
 
-    var kerning: CGFloat {
-        switch style {
-        case .caption:          return 1.12
-        default:                return 1
-        }
-    }
-
     var casing: Text.Case? {
         switch style {
         case .largeCaption, .caption: return .uppercase
@@ -68,7 +61,6 @@ public struct Typography: ViewModifier {
             .lineSpacing(spacing) // Only works between lines in a paragraph.
             .padding(.vertical, spacing) // Adds the space around the text block.
             .textCase(casing)
-            .kerning(kerning)
     }
 }
 


### PR DESCRIPTION
Reverts powerhome/playbook-apple#20

Actually this API doesn't exist before iOS 16 and while fixing it I realized this entire kit needs to be reimagined. I'm working on a replacement but this should be reverted until the fix is done.