### PR TITLE
[PBIOS-20] Fix `PBIconCircle` to Match Playbook Web

### DIFF
--- a/Sources/Playbook/Icon/PBIconCircle.swift
+++ b/Sources/Playbook/Icon/PBIconCircle.swift
@@ -49,6 +49,7 @@ fileprivate extension View {
     }
 }
 
+@available(macOS 13.0, *)
 struct PBIconCircle_Previews: PreviewProvider {
     static var previews: some View {
         registerFonts()


### PR DESCRIPTION
# What does this PR do?

- Matches the `PBIconCircle` iOS to the [web version](https://playbook.powerapp.cloud/kits/icon_circle/react)
  - Default color is now `.pBDefault`
  - Update documentation
- [Runway](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-20)
____

#### Screens

**Before**
![Screenshot 2023-02-06 at 7 32 52 PM](https://user-images.githubusercontent.com/47684670/217332047-f1939cdb-23ea-4249-9ccb-8b76e0871032.png)

**After**
![Screenshot 2023-02-06 at 7 34 17 PM](https://user-images.githubusercontent.com/47684670/217332091-f7633395-8a4b-4995-b3df-9c424f7cf52c.png)

#### Breaking Changes

No

#### How to test this

- View in `xcode`

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new component`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **SCREENSHOT** Please add a screen shot or two.
