### PR TITLE
[PBIOS-15] Fix `PBCircleIcon` (Button) Extra Padding

### DIFF
--- a/Sources/Playbook/Button/PBCircleIcon.swift
+++ b/Sources/Playbook/Button/PBCircleIcon.swift
@@ -21,12 +21,9 @@ public struct PBCircleIcon: View {
       .frame(minWidth: 38, minHeight: 38)
       .background(variant.backgroundColor)
       .foregroundColor(variant.foregroundColor)
-      .pbFont(.buttonText())
       .clipShape(Circle())
   }
 }
-
-// MARK: - Variant enum
 
 public extension PBCircleIcon {
   enum Variant {
@@ -48,17 +45,13 @@ public extension PBCircleIcon {
   }
 }
 
-// MARK: - Preview
-
 struct PBCircleIcon_Previews: PreviewProvider {
   static var previews: some View {
     registerFonts()
 
     return VStack {
-      VStack {
-          PBCircleIcon(icon: PBIcon(FontAwesome.plus, size: .small), variant: .secondary)
-      }
-      .background(Color.pbBackground)
+      PBCircleIcon(icon: PBIcon(FontAwesome.plus, size: .small), variant: .secondary)
     }
+    .background(Color.pbBackground)
   }
 }


### PR DESCRIPTION
# What does this PR do?

- Removes extra `.pbFont` that was causing extra padding on the kit
- Removes unnecessary `VStack` in the preview

[Runway story](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-15)
____

#### Screens

(Blue border is Preview's selection feature to assist with visibility)

**Light Mode - Extra Padding Gone**
![Screenshot 2023-02-07 at 4 21 24 PM](https://user-images.githubusercontent.com/47684670/217374656-037f7a8d-256e-48bf-ae66-c1b30ea2f1a8.png)

**Dark Mode - Extra Padding Gone**
![Screenshot 2023-02-07 at 4 20 46 PM](https://user-images.githubusercontent.com/47684670/217374793-43925a0d-1d37-4d70-8a7c-d80a5b3e3f45.png)

#### Breaking Changes

No

#### How to test this

- View in `xcode`

#### Checklist:

- [X] **LABELS** Add a label: `enhancement`, `bug`, `improvement`, `new component`, `deprecated`, or `breaking`. See [Changelog & Labels](https://github.com/powerhome/playbook/wiki/Changelog-&-Labels) for details.
- [X] **SCREENSHOT** Please add a screen shot or two.
