### PR TITLE
[PBIOS-69] Release Version 2.1.2

### DIFF
--- a/Sources/Playbook/Components/Icon/PBIcon.swift
+++ b/Sources/Playbook/Components/Icon/PBIcon.swift
@@ -36,7 +36,6 @@ public extension PBIcon {
     /// 24
     case large
 
-    // swiftlint:disable identifier_name
     case x1
     case x2
     case x3

--- a/Sources/Playbook/Components/Select/PBSelect.swift
+++ b/Sources/Playbook/Components/Select/PBSelect.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 public struct PBSelect: ButtonStyle {
-  let title: String
+  let title: String?
   let style: PBCardStyle
 
-  public init(_ title: String, style: PBCardStyle) {
+  public init(_ title: String?, style: PBCardStyle) {
     self.title = title
     self.style = style
   }
@@ -22,6 +22,7 @@ public struct PBSelect: ButtonStyle {
         Text(title)
           .pbFont(.caption, color: .pbTextLight)
       }
+
       PBCard(padding: 0, style: style) {
         HStack {
           configuration.label

--- a/Sources/Playbook/Design Elements/Iconography/FontAwesome.swift
+++ b/Sources/Playbook/Design Elements/Iconography/FontAwesome.swift
@@ -1516,9 +1516,9 @@ public enum FontAwesome: String, PlaybookGenericIcon, CaseIterable {
   case youtubeSquare = "fa-youtube-square"
   case zhihu = "fa-zhihu"
 
-    public var fontFamily: String {
-      "Font Awesome 6 Pro"
-    }
+  public var fontFamily: String {
+    "Font Awesome 6 Pro"
+  }
 
   /// An unicode code of FontAwesome icon
   public var unicodeString: String {
@@ -3449,9 +3449,9 @@ public enum FontAwesomeBrands: String, PlaybookGenericIcon {
   case youtubeSquare = "fa-youtube-square"
   case zhihu = "fa-zhihu"
 
-    public var fontFamily: String {
-      "Font Awesome 6 Brands"
-    }
+  public var fontFamily: String {
+    "Font Awesome 6 Brands"
+  }
 
   /// An unicode code of FontAwesome icon
   public var unicodeString: String {
@@ -3917,3 +3917,4 @@ public enum FontAwesomeBrands: String, PlaybookGenericIcon {
     }
   }
 }
+// swiftlint:enable file_length type_body_length


### PR DESCRIPTION
## Summary
- Fixes the optional type error in `PBSelect` after upgrading to Xcode 14.3
- Fixes linter warnings and formatter errors

## Additional Details
- [Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-69)
- Errors:
<br /><img width="442" alt="Errors" src="https://user-images.githubusercontent.com/47684670/229551300-1d0e5143-ffa8-43e9-9834-73b65c5b2efc.png">

## Breaking Changes

No. In `PBSelect`, the team only needed to make the `title` property optional and fixes linter warnings and formatter errors.

## Testing

Tested locally.

## Checklist

- [X] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, `enhancement`, or `improvement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [X] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [X] **TESTING** - Have you tested your story?
