### PR TITLE
Disable SwiftLint nesting rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 disabled_rules: # rule identifiers to exclude from running
   - identifier_name
   - function_body_length
+  - nesting
   - todo
 
 opt_in_rules: # some rules are only opt-in


### PR DESCRIPTION
## Summary
- Disables the nesting rule for SwiftLint
- Warning appeared in the new Color file, but Isis would like to disable it

<img width="248" alt="Warning" src="https://user-images.githubusercontent.com/47684670/233712664-7442fae9-0a49-48c6-a4b4-5f0accf28c6c.png">

<img width="859" alt="Line of Violation" src="https://user-images.githubusercontent.com/47684670/233712650-bebae9b5-353e-4536-ad18-d850f8ee691a.png">
