### PR TITLE
Button extension: Remove unnecessary shape parameter

### DIFF
--- a/Sources/Playbook/Components/Button/PBButtonStyle.swift
+++ b/Sources/Playbook/Components/Button/PBButtonStyle.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 public struct PBButtonStyle: ButtonStyle {
   var variant: PBButtonVariant
-  var shape: PBButtonShape
   var size: PBButtonSize
   @State private var isHovering = false
 

--- a/Sources/Playbook/Components/Button/PBCircleButtonStyle.swift
+++ b/Sources/Playbook/Components/Button/PBCircleButtonStyle.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 public struct PBCircleButtonStyle: ButtonStyle {
   var variant: PBButtonVariant
-  var shape: PBButtonShape
   var size: PBButtonSize
   @State private var isHovering = false
 

--- a/Sources/Playbook/Resources/Extensions/Button+Style.swift
+++ b/Sources/Playbook/Resources/Extensions/Button+Style.swift
@@ -1,6 +1,6 @@
 //
 //  Button+Style.swift
-//  
+//
 //
 //  Created by Gavin Huang on 4/26/23.
 //
@@ -19,7 +19,6 @@ extension Button {
       self.buttonStyle(
         PBButtonStyle(
           variant: variant,
-          shape: shape,
           size: size
         )
       )
@@ -27,7 +26,6 @@ extension Button {
       self.buttonStyle(
         PBCircleButtonStyle(
           variant: variant,
-          shape: shape,
           size: size
         )
       )


### PR DESCRIPTION
## Summary
- Removes non-breaking code. There's an unnecessary `shape` parameter from the `Button+Style` extension.