### PR TITLE
[PBIOS-29] Remove Andrew's picture and last name

### DIFF
--- a/Sources/Playbook/Components/Message/PBMessage.swift
+++ b/Sources/Playbook/Components/Message/PBMessage.swift
@@ -50,7 +50,7 @@ struct PBMessage_Previews: PreviewProvider {
 
     return PBMessage(
       avatar: PBAvatar(image: Image("andrew", bundle: .module)),
-      label: "Andrew Koeckler", timestamp: PBTimestamp(Date(), showDate: false)
+      label: "Andrew Black", timestamp: PBTimestamp(Date(), showDate: false)
     ) {
       Text("This below ir our great friend (and amazing dev), aka me, Andrew:").pbFont(.body())
       Image("andrew", bundle: .module).resizable().frame(width: 240, height: 240)

--- a/Sources/Playbook/Components/Time And Date/PBTimestamp.swift
+++ b/Sources/Playbook/Components/Time And Date/PBTimestamp.swift
@@ -198,7 +198,7 @@ struct PBTimestamp_Previews: PreviewProvider {
           PBTimestamp(
             Date().addingTimeInterval(-12),
             showUser: true,
-            text: "Andrew Koeckler",
+            text: "Andrew Black",
             variant: .updated
           )
           .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)
@@ -212,7 +212,7 @@ struct PBTimestamp_Previews: PreviewProvider {
           PBTimestamp(
             Date().addingTimeInterval(-10),
             showUser: true,
-            text: "Andrew Koeckler",
+            text: "Andrew Black",
             variant: .elapsed
           )
           .frame(minWidth: minWidth, maxWidth: .infinity, alignment: .leading)

--- a/Sources/Playbook/Components/User/PBMultipleUsers.swift
+++ b/Sources/Playbook/Components/User/PBMultipleUsers.swift
@@ -78,8 +78,8 @@ struct PBMultipleUsers_Previews: PreviewProvider {
   static var previews: some View {
     registerFonts()
 
-    let andrew = PBUser(name: "Andrew Kloecker")
-    let picAndrew = PBUser(name: "Andrew Kloecker", image: Image("andrew", bundle: .module))
+    let andrew = PBUser(name: "Andrew Black")
+    let picAndrew = PBUser(name: "Andrew Black", image: Image("andrew", bundle: .module))
     let twoUsers = [andrew, picAndrew]
     let multipleUsers = [andrew, picAndrew, andrew, andrew, andrew]
 

--- a/Sources/Playbook/Components/User/PBMultipleUsersStacked.swift
+++ b/Sources/Playbook/Components/User/PBMultipleUsersStacked.swift
@@ -45,8 +45,8 @@ struct PBMultipleUsersStacked_Previews: PreviewProvider {
   static var previews: some View {
     registerFonts()
 
-    let andrew = PBUser(name: "Andrew Kloecker")
-    let picAndrew = PBUser(name: "Andrew Kloecker", image: Image("andrew", bundle: .module))
+    let andrew = PBUser(name: "Andrew Black")
+    let picAndrew = PBUser(name: "Andrew Black", image: Image("andrew", bundle: .module))
     let oneUser = [andrew]
     let twoUsers = [andrew, picAndrew]
     let multipleUsers = [andrew, picAndrew, andrew, andrew]

--- a/Sources/Playbook/Components/User/PBUser.swift
+++ b/Sources/Playbook/Components/User/PBUser.swift
@@ -102,7 +102,7 @@ struct PBUser_Previews: PreviewProvider {
   static var previews: some View {
     registerFonts()
     let img = Image("andrew", bundle: .module)
-    let name = "Andrew Kloecker"
+    let name = "Andrew Black"
     let title = "Rebels Developer"
 
     return Group {


### PR DESCRIPTION
## Summary
- Replaced Andrew's last name with "Black"
- Ensured his picture and name is no longer used in PB Swift

## Additional Details
- [Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-29)

## Breaking Changes

No

## Testing

N/A

## Checklist

- [X] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
