### PR TITLE
[RANGR-149] Enable Intel machines for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 success = true
-defaultNode = 'xcode-14 && !i386'
+defaultNode = 'xcode-14'
 
 stage('Build number') {
   node(defaultNode) {


### PR DESCRIPTION
## Summary
- Enable Intel machines on Jenkinsfile, so more machines are available.

## Additional Details
- Also generating this version for testing if Colin and Justin's AppCenter setup is working.

## Breaking Changes

No, just enabling more CI machines.

## Testing

CI build should keep working.

## Checklist

- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
