### PR TITLE
[RANGR-427] Shipping app to Beta on PR builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def steps = [
   'iOS': {
     runNode {
       getReleaseNotes()
-      def args = prepareToBuild(buildType())
+      def args = "build_number:${buildNumber} type:${buildType()}"
       buildAndShipiOS(args)
     }
   // }, 'macOS': {
@@ -114,11 +114,14 @@ def runNodeWith(label, block, isShort) {
   }
 }
 
-def prepareToBuild(String buildType) {
+def prepareToBuild(String buildType, String flavor) {
   def fastlaneOpts = ''
   stage('Prepare') {
-    fastlaneOpts = "build_number:${buildNumber} type:${buildType}"
+    sh "make ${flavor}-${buildType} && sleep 1"
+    fastlaneOpts = "build_number:${buildNumber} type:${buildType} flavor:${flavor}"
+    fastlane("setup_before_build ${fastlaneOpts}")
   }
+  checkForFailedParallelJob()
   return fastlaneOpts
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,10 +24,7 @@ derived_data_path = "DerivedData"
 desc "Build iOS"
 lane :build_ios do |opts|
 
-  export_method = 'ad-hoc'
-  if opts[:type] == 'production'
-    export_method = 'enterprise'
-  end
+  export_method = 'enterprise'
 
   gym(
     project: './PlaybookShowcase/PlaybookShowcase.xcodeproj',


### PR DESCRIPTION
## Summary
- This task updates CI so PR builds and development merges ship the .ipa to AppCenter's [Playbook Swift Beta](https://appcenter.ms/orgs/powerhome/apps/Playbook-Showcase-Beta) instead of [Playbook Swift](https://appcenter.ms/orgs/powerhome/apps/Playbook-Showcase). 
Main merges still goes to Playbook Swift.

## Additional Details
- [Runway Story](https://nitro.powerhrg.com/runway/backlog_items/RANGR-427)

## Breaking Changes

No, only CI work.

## Testing

It is possible [to verify here](https://appcenter.ms/orgs/powerhome/apps/Playbook-Showcase-Beta/distribute/releases) the version was send to the beta app.
When merging on main, we should see [the version here](https://appcenter.ms/orgs/powerhome/apps/Playbook-Showcase/distribute/releases).

## Checklist

- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
