### PR TITLE
[PBIOS-118] Refactoring PBCheckbox showcase doc

### DIFF
--- a/Sources/Playbook/Components/Checkbox/CheckboxCatalog.swift
+++ b/Sources/Playbook/Components/Checkbox/CheckboxCatalog.swift
@@ -16,16 +16,18 @@ public struct CheckboxCatalog: View {
             .padding(.bottom, Spacing.small)
 
           PBCheckbox(checked: true, text: "Checked", action: {})
-            .padding(.bottom, Spacing.small)
+        }
 
+        PBDoc(title: "Error") {
           PBCheckbox(
             checked: false,
             checkboxType: .error,
             text: "Error",
             action: {}
           )
-          .padding(.bottom, Spacing.small)
+        }
 
+        PBDoc(title: "Indeterminate") {
           PBCheckbox(
             checked: true,
             checkboxType: .indeterminate,


### PR DESCRIPTION
## Summary
- Refactoring the PBCheckbox Showcase docs to align with other validated kits' examples.

## Additional Details
- [Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-118)

## Screenshots (for UI stories: show before/after changes)
<img width="356" alt="Screenshot 2023-08-15 at 13 17 48" src="https://github.com/powerhome/PlaybookSwift/assets/2573205/86526287-6912-40aa-8abc-b764a52f13de">
<img width="360" alt="Screenshot 2023-08-16 at 01 52 58" src="https://github.com/powerhome/PlaybookSwift/assets/2573205/dad7fe98-ba99-402b-bdcd-c0295aa52afb">

## Breaking Changes

No

## Testing

[Insert testing details or N/A]

## Checklist

- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [x] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
