### PR TITLE
[PBIOS-176] Add Dependencies Label to Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     ":dependencyDashboard",
     "group:allNonMajor"
   ],
-  "labels": ["improvement"],
+  "labels": ["dependencies"],
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary
- As a developer, I want to properly label Renovate (bot) PR builds so that I can track them in the release notes.

## Additional Details
- [Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-176)

## Screenshots (for UI stories: show before/after changes)
N/A

## Breaking Changes
No

## Testing
Merge to production and see that all renovate generated PRs are labeled with `development`

## Checklist

- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
