### PR TITLE
[PBIOS-177] Ignore Runway Comment Creation for Stubbed Runway Story ID

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ def getReleaseNotes() {
 }
 
 def writeRunwayComment() {
-  if (env.PR_USER_HANDLE in ['renovate', 'dependabot']) {
+  if (env.PR_USER_HANDLE in ['renovate', 'dependabot'] || "${RUNWAY_BACKLOG_ITEM_ID}" == env.FAKE_RUNWAY_STORY_ID) {
     echo "Bot PR detected. Skipping Runway comment."
     return true
   }

--- a/Tools/setup-story-details.sh
+++ b/Tools/setup-story-details.sh
@@ -15,6 +15,8 @@ mkdir -p "$BUILD_ROOT"
 
 # Nitro Runway
 
+export FAKE_RUNWAY_STORY_ID="PBIOS-000"
+
 echo ""
 echo "****************************"
 echo "*    Runway PR Details     *"
@@ -66,7 +68,7 @@ if [ -n "$GITHUB_PULL_REQUEST_ID" ]; then
     echo "RUNWAY_BACKLOG_ITEM_ID = $RUNWAY_BACKLOG_ITEM_ID"
   elif [[ -z "$RUNWAY_BACKLOG_ITEM_ID" ]]; then
       echo "No backlog item ID found, setting ID to 000, this could be Renovate bot or wrong PR title."
-      RUNWAY_BACKLOG_ITEM_ID="PBIOS-000"
+      RUNWAY_BACKLOG_ITEM_ID=$FAKE_RUNWAY_STORY_ID
   fi
 else
   echo "Not building a pull request - locating Runway Backlog Item ID in last commit message"


### PR DESCRIPTION
## Summary
- Also ignores `PBIOS-000` aka "stubbed" story ID. 
  -  This occurs when there is no Runway story for the PR (renovate)

## Additional Details
- [Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-177)

## Screenshots (for UI stories: show before/after changes)

N/A

## Breaking Changes

No

## Testing

Can be seen working in this `renovate` [generated PR:](https://github.com/powerhome/PlaybookSwift/pull/176)

## Checklist

- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [x] **TESTING** - Have you tested your story?
