### PR TITLE
[PBIOS-175] 🛠️ Ensure only Releases (not builds) get tags in Github

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,9 @@ runShortNode {
     writeRunwayComment()
   }
   stage('Tag') {
-    try { fastlane("tag_build build:${buildNumber}") } catch (e) { }
+    if (env.GITHUB_BRANCH_NAME == "main") {
+      try { fastlane("tag_build build:${buildNumber}") } catch (e) { }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
As a developer, I want to only create Github tags for releases, not builds, so that I can easily locate my releases in Github.

## Additional Details
- [Runway Story](https://nitro.powerhrg.com/runway/backlog_items/PBIOS-175)

## Screenshots (for UI stories: show before/after changes)
N/A

## Breaking Changes
No

## Testing

1. This PR should **not** create a tag in GH for the build.
2. Releases should get a GH tag/release

## Checklist

- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
