### PR TITLE
[PBIOS-232]User Kit Spacing fix

### DIFF
--- a/Sources/Playbook/Components/User/PBUser.swift
+++ b/Sources/Playbook/Components/User/PBUser.swift
@@ -60,7 +60,7 @@ public struct PBUser: View {
           PBAvatar(image: image, name: name, size: size.avatarSize)
         }
 
-        VStack(alignment: .leading, spacing: size == .large ? Spacing.large : 6) {
+        VStack(alignment: .leading, spacing: Spacing.xSmall) {
           Text(name)
             .font(titleStyle.font)
             .foregroundColor(.text(.default))
@@ -68,12 +68,12 @@ public struct PBUser: View {
         }
       }
     } else {
-      VStack(spacing: Spacing.large) {
+      VStack(spacing: Spacing.xSmall) {
         if displayAvatar {
           PBAvatar(image: image, name: name, size: size.avatarSize)
         }
 
-        VStack(alignment: displayAvatar ? .center : .leading, spacing: 6) {
+        VStack(alignment: displayAvatar ? .center : .leading, spacing: Spacing.xSmall) {
           Text(name)
             .font(titleStyle.font)
             .foregroundColor(.text(.default))


### PR DESCRIPTION
## Summary
- Fixed Spacing in User Kit


## Screenshots (for UI stories: show before/after changes)

| Before | After |
| -------- | ------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-07 at 13 37 17](https://github.com/powerhome/PlaybookSwift/assets/54749071/4f0fcdc8-c8bc-4231-a27d-82004c6c17d3) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-07 at 13 32 54](https://github.com/powerhome/PlaybookSwift/assets/54749071/a74cf12e-6534-42b5-a030-70e655530a91) |
| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-07 at 13 32 49](https://github.com/powerhome/PlaybookSwift/assets/54749071/f3cc94c8-f339-4e98-a4b8-00bd65e74698) | ![Simulator Screenshot - iPhone 15 Pro - 2023-12-07 at 13 37 12](https://github.com/powerhome/PlaybookSwift/assets/54749071/0f172c58-ce45-4f19-91b2-18b07b98a9f1) |


## Checklist

- [ x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [x ] **SCREENSHOTS** - Please add a screenshot or two. For UI changes, you MUST provide before and after screenshots.
- [ x] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ x] **TESTING** - Have you tested your story?
