### PR TITLE
[PBIOS-299] Release 4.12.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,16 @@
+4.12.0
 
+MARCH 18, 2024
+
+List of changes:
+
+** Kit Enhancements: **
+
+Time Stacked kit #298 Rachel
+Time Range Inline kit #298 Rachel
+Currency Kit #291 Rachel
+** Improvements: **
+
+Time Kit function rework #294 Rachel
+Add Presence Indicator to User Kit #292 Rachel
+Remove Year From Date Kit When Current #300 Rachel

--- a/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
+++ b/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
@@ -298,7 +298,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.11.0;
+				MARKETING_VERSION = 4.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -336,7 +336,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.11.0;
+				MARKETING_VERSION = 4.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Playbook In House";
@@ -376,7 +376,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 4.11.0;
+				MARKETING_VERSION = 4.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -411,7 +411,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 4.11.0;
+				MARKETING_VERSION = 4.12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Playbook Showcase Dev ID";

--- a/project.yml
+++ b/project.yml
@@ -22,7 +22,7 @@ targets:
         GENERATE_INFOPLIST_FILE: false
         PRODUCT_BUNDLE_IDENTIFIER: com.powerhrg.PlaybookShowcase
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: 4.11.0
+        MARKETING_VERSION: 4.12.0
   Playbook-macOS:
     type: application
     platform: macOS
@@ -35,4 +35,4 @@ targets:
         GENERATE_INFOPLIST_FILE: false
         PRODUCT_BUNDLE_IDENTIFIER: com.powerhrg.PlaybookShowcase
         CURRENT_PROJECT_VERSION: 1
-        MARKETING_VERSION: 4.11.0
+        MARKETING_VERSION: 4.12.0


### PR DESCRIPTION
**What does this PR do?** 
Playbook Swift version update

4.12.0

MARCH 18, 2024

List of changes:

** Kit Enhancements: **

Time Stacked kit https://github.com/powerhome/playbook-swift/pull/298 [Rachel](https://github.com/RachelRadford21)
Time Range Inline kit https://github.com/powerhome/playbook-swift/pull/297 [Rachel](https://github.com/RachelRadford21)
Currency Kit https://github.com/powerhome/playbook-swift/pull/293 [Rachel](https://github.com/RachelRadford21)
** Improvements: **

Time Kit function rework https://github.com/powerhome/playbook-swift/pull/294 [Rachel](https://github.com/RachelRadford21)
Add Presence Indicator to User Kit https://github.com/powerhome/playbook-swift/pull/292 [Rachel](https://github.com/RachelRadford21)
Remove Year From Date Kit When Current https://github.com/powerhome/playbook-swift/pull/300 [Rachel](https://github.com/RachelRadford21)
Full Changelog: https://github.com/powerhome/playbook-swift/compare/4.11.1...4.12.0