### PR TITLE
[PBIOS-347] Typography line height validation

### DIFF
--- a/Sources/Playbook/Components/Message/MessageCatalog.swift
+++ b/Sources/Playbook/Components/Message/MessageCatalog.swift
@@ -95,3 +95,8 @@ public struct MessageCatalog: View {
     .navigationTitle("Message")
   }
 }
+
+#Preview {
+  registerFonts()
+  return MessageCatalog()
+}

--- a/Sources/Playbook/Components/Message/PBMessage.swift
+++ b/Sources/Playbook/Components/Message/PBMessage.swift
@@ -20,7 +20,6 @@ public struct PBMessage<Content: View>: View {
   let horizontalPadding: CGFloat
   let content: Content?
   let timestampVariant: PBTimestamp.Variant
-
   @State private var isHovering: Bool = false
 
   public init(
@@ -31,8 +30,8 @@ public struct PBMessage<Content: View>: View {
     timestampAlignment: TimestampAlignment? = .trailing,
     timestampVariant: PBTimestamp.Variant = .standard,
     changeTimeStampOnHover: Bool = false,
-    verticalPadding: CGFloat = Spacing.xSmall,
-    horizontalPadding: CGFloat = Spacing.xSmall,
+    verticalPadding: CGFloat = Spacing.none,
+    horizontalPadding: CGFloat = Spacing.none,
     @ViewBuilder content: (() -> Content) = { EmptyView() }
   ) {
     self.avatar = avatar
@@ -54,8 +53,7 @@ public struct PBMessage<Content: View>: View {
       }
       VStack(alignment: .leading, spacing: Spacing.none) {
         HStack(spacing: Spacing.xSmall) {
-          Text(label)
-            .pbFont(.messageTitle)
+          Text(label).pbFont(.messageTitle)
           if timestampAlignment == .trailing {
             Spacer()
           }
@@ -72,10 +70,7 @@ public struct PBMessage<Content: View>: View {
         .frame(maxWidth: .infinity, alignment: .topLeading)
 
         if let message = message {
-          Text(message)
-            .pbFont(.messageBody)
-            .fontWeight(FontWeight.regular)
-            .lineSpacing(Spacing.xxSmall + 2)
+          Text(message).pbFont(.messageBody)
         }
         content
       }
@@ -103,9 +98,7 @@ public extension PBMessage {
   }
 }
 
-struct PBMessage_Previews: PreviewProvider {
-  static var previews: some View {
-    registerFonts()
-    return MessageCatalog()
-  }
+#Preview {
+  registerFonts()
+  return MessageCatalog()
 }

--- a/Sources/Playbook/Components/Message/PBMessage.swift
+++ b/Sources/Playbook/Components/Message/PBMessage.swift
@@ -65,6 +65,7 @@ public struct PBMessage<Content: View>: View {
               showUser: false,
               variant: returnTimestamp(isHovering: isHovering)
             )
+            .frame(height: 16.8)
           }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)

--- a/Sources/Playbook/Components/Time And Date/PBTimestamp.swift
+++ b/Sources/Playbook/Components/Time And Date/PBTimestamp.swift
@@ -132,10 +132,7 @@ public extension PBTimestamp {
   }
 }
 
-public struct PBTimestamp_Previews: PreviewProvider {
-  public static var previews: some View {
-    registerFonts()
-
-    return TimeStampCatalog()
-  }
+#Preview {
+  registerFonts()
+  return TimeStampCatalog()
 }

--- a/Sources/Playbook/Design Elements/Typography/Typography.swift
+++ b/Sources/Playbook/Design Elements/Typography/Typography.swift
@@ -23,7 +23,6 @@ public struct Typography: ViewModifier {
       .lineSpacing(lineSpacing)
       .textCase(casing)
       .foregroundColor(foregroundColor)
-      .border(Color.pink, width: /*@START_MENU_TOKEN@*/1/*@END_MENU_TOKEN@*/)
   }
 }
 
@@ -55,22 +54,21 @@ private extension Typography {
     case .largeCaption: return 5
     case .messageTitle: return 1.4
     case .messageBody: return 3
-    case .badgeText: return 0
-    default: return 3.2
+    default: return 0
     }
   }
-  
+
   var lineSpacing: CGFloat {
     switch font {
-    case .title1: return 4.6
-    case .title2: return -0.7
-    case .title3: return 2.8
-    case .title4: return 1.6
-    case .body: return 3.2
-    case .detail: return 2.8
-    case .caption, .subcaption: return 3
-    case .largeCaption: return 5
-    case .messageTitle: return 1.4
+    case .title1: return 9
+    case .title2: return 0
+    case .title3: return 5.4
+    case .title4: return 3
+    case .body: return 6.2
+    case .detail: return 5.4
+    case .caption, .subcaption: return 5.8
+    case .largeCaption: return 9.8
+    case .messageTitle: return 2.6
     case .messageBody: return 6
     default: return 0
     }

--- a/Sources/Playbook/Design Elements/Typography/Typography.swift
+++ b/Sources/Playbook/Design Elements/Typography/Typography.swift
@@ -14,6 +14,20 @@ public struct Typography: ViewModifier {
   var variant: Variant
   var color: Color?
 
+  public func body(content: Content) -> some View {
+    content
+      .font(font.font)
+      .tracking(letterSpacing)
+      .fontWeight(fontWeight)
+      .padding(.vertical, spacing)
+      .lineSpacing(lineSpacing)
+      .textCase(casing)
+      .foregroundColor(foregroundColor)
+      .border(Color.pink, width: /*@START_MENU_TOKEN@*/1/*@END_MENU_TOKEN@*/)
+  }
+}
+
+private extension Typography {
   var foregroundColor: Color {
     if let color = color {
       return color
@@ -43,6 +57,22 @@ public struct Typography: ViewModifier {
     case .messageBody: return 3
     case .badgeText: return 0
     default: return 3.2
+    }
+  }
+  
+  var lineSpacing: CGFloat {
+    switch font {
+    case .title1: return 4.6
+    case .title2: return -0.7
+    case .title3: return 2.8
+    case .title4: return 1.6
+    case .body: return 3.2
+    case .detail: return 2.8
+    case .caption, .subcaption: return 3
+    case .largeCaption: return 5
+    case .messageTitle: return 1.4
+    case .messageBody: return 6
+    default: return 0
     }
   }
 
@@ -77,16 +107,6 @@ public struct Typography: ViewModifier {
     default: return FontWeight.regular
     }
   }
-  
-  public func body(content: Content) -> some View {
-    content
-      .font(font.font)
-      .tracking(letterSpacing)
-      .fontWeight(fontWeight)
-      .padding(.vertical, spacing)
-      .textCase(casing)
-      .foregroundColor(foregroundColor)
-  }
 }
 
 public extension Typography {
@@ -114,9 +134,7 @@ public extension View {
   }
 }
 
-public struct Typography_Previews: PreviewProvider {
-  public static var previews: some View {
-    registerFonts()
-    return TypographyCatalog()
-  }
+#Preview {
+  registerFonts()
+  return TypographyCatalog()
 }

--- a/Sources/Playbook/Design Elements/Typography/TypographyCatalog.swift
+++ b/Sources/Playbook/Design Elements/Typography/TypographyCatalog.swift
@@ -11,53 +11,75 @@ import SwiftUI
 
 public struct TypographyCatalog: View {
   public var body: some View {
-    let title = PBDoc(title: "Title") {
-      VStack(alignment: .leading, spacing: Spacing.small) {
-        Text("Title 1")
-          .pbFont(.title1)
-        Text("Title 2")
-          .pbFont(.title2)
-        Text("Title 3")
-          .pbFont(.title3)
-        Text("Title 4")
-          .pbFont(.title4)
-        Text("Title 4 Link Variant")
-          .pbFont(.title4, variant: .link)
+    ScrollView {
+      VStack(spacing: Spacing.medium) {
+        PBDoc(title: "Title") { title }
+        PBDoc(title: "Title Light Weight") { titleLight }
+        PBDoc(title: "Text size") { textSize }
+        PBDoc(title: "Letter spacing") { letterSpacing }
+        PBDoc(title: "Components Text") { componentsText }
+        PBDoc(title: "Caption") { caption }
+        PBDoc(title: "Detail") { detail }
+        PBDoc(title: "Message") { message }
       }
+      .padding(Spacing.medium)
     }
+    .background(Color.background(Color.BackgroundColor.light))
+    .navigationTitle("Typography")
+  }
+}
 
-    let titleLight = PBDoc(title: "Title Light Weight") {
-      VStack(alignment: .leading, spacing: Spacing.small) {
-        Text("Title 1")
-          .pbFont(.title1, variant: .light)
-        Text("Title 2")
-          .pbFont(.title2, variant: .light)
-        Text("Title 3")
-          .pbFont(.title3, variant: .light)
-      }
+private extension TypographyCatalog {
+  var title: some View {
+    VStack(alignment: .leading, spacing: Spacing.small) {
+      Text("Title 1")
+        .pbFont(.title1)
+      Text("Title 2")
+        .pbFont(.title2)
+      Text("Title 3")
+        .pbFont(.title3)
+      Text("Title 4")
+        .pbFont(.title4)
+      Text("Title 4 Link Variant")
+        .pbFont(.title4, variant: .link)
     }
-
-    let body = PBDoc(title: "Text size") {
-      ForEach(TextSize.Body.allCases, id: \.rawValue) { size in
-        Text("Text size \(Int(size.rawValue)) px")
-          .pbFont(.monogram(size.rawValue))
-      }
+  }
+  
+  var titleLight: some View {
+    VStack(alignment: .leading, spacing: Spacing.small) {
+      Text("Title 1")
+        .pbFont(.title1, variant: .light)
+      Text("Title 2")
+        .pbFont(.title2, variant: .light)
+      Text("Title 3")
+        .pbFont(.title3, variant: .light)
     }
-
-    let letterSpacing = PBDoc(title: "Letter spacing") {
-      ForEach(LetterSpacing.allCases, id: \.rawValue) { space in
-        Text(space.rawValue).tracking(PBFont.body.space(space, font: .body))
-      }
+  }
+  
+  var textSize: some View {
+    ForEach(TextSize.Body.allCases, id: \.rawValue) { size in
+      Text("Text size \(Int(size.rawValue)) px")
+        .pbFont(.monogram(size.rawValue))
     }
-
-    let componentsText = PBDoc(title: "Components Text") {
+  }
+  
+  var letterSpacing: some View {
+    ForEach(LetterSpacing.allCases, id: \.rawValue) { space in
+      Text(space.rawValue).tracking(PBFont.body.space(space, font: .body))
+    }
+  }
+  
+  var componentsText: some View {
+    VStack(alignment: .leading, spacing: Spacing.small) {
       Text("Button Text")
         .pbFont(.buttonText())
       Text("Badge Text")
         .pbFont(.badgeText)
     }
-
-    let caption = PBDoc(title: "Caption") {
+  }
+  
+  var caption: some View {
+    VStack(alignment: .leading, spacing: Spacing.small) {
       Text("Large Caption")
         .pbFont(.largeCaption)
       Text("Caption")
@@ -67,35 +89,34 @@ public struct TypographyCatalog: View {
       Text("Subcaption Link Variant")
         .pbFont(.subcaption, variant: .link)
     }
-
-    let detail = PBDoc(title: "Detail") {
+  }
+  
+  var detail: some View {
+    VStack(alignment: .leading, spacing: Spacing.small) {
       Text("I am a detail kit")
         .pbFont(.detail(false))
       Text("I am a detail kit")
         .pbFont(.detail(true))
     }
-    
-    let message = PBDoc(title: "Message") {
+  }
+  
+  var message: some View {
+    VStack(spacing: Spacing.none) {
       Text("Message Title")
         .pbFont(.messageTitle)
-      Text("Message Body")
+      
+      Text("Message Body Message Body Message Body Message Body Message Body ")
         .pbFont(.messageBody)
+        .background(GeometryReader(content: { geometry in
+          Color.pink.opacity(0.2).onAppear {
+            print("Size message body: \(geometry.size)")
+          }
+        }))
     }
-
-    return ScrollView {
-      VStack(spacing: Spacing.medium) {
-        title
-        titleLight
-        body
-        letterSpacing
-        componentsText
-        caption
-        detail
-        message
-      }
-      .padding(Spacing.medium)
-    }
-    .background(Color.background(Color.BackgroundColor.light))
-    .navigationTitle("Typography")
   }
+}
+
+#Preview {
+  registerFonts()
+  return TypographyCatalog()
 }

--- a/Sources/Playbook/Design Elements/Typography/TypographyCatalog.swift
+++ b/Sources/Playbook/Design Elements/Typography/TypographyCatalog.swift
@@ -31,7 +31,7 @@ public struct TypographyCatalog: View {
 
 private extension TypographyCatalog {
   var title: some View {
-    VStack(alignment: .leading, spacing: Spacing.small) {
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
       Text("Title 1")
         .pbFont(.title1)
       Text("Title 2")
@@ -46,7 +46,7 @@ private extension TypographyCatalog {
   }
   
   var titleLight: some View {
-    VStack(alignment: .leading, spacing: Spacing.small) {
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
       Text("Title 1")
         .pbFont(.title1, variant: .light)
       Text("Title 2")
@@ -57,20 +57,24 @@ private extension TypographyCatalog {
   }
   
   var textSize: some View {
-    ForEach(TextSize.Body.allCases, id: \.rawValue) { size in
-      Text("Text size \(Int(size.rawValue)) px")
-        .pbFont(.monogram(size.rawValue))
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
+      ForEach(TextSize.Body.allCases, id: \.rawValue) { size in
+        Text("Text size \(Int(size.rawValue)) px")
+          .pbFont(.monogram(size.rawValue))
+      }
     }
   }
   
   var letterSpacing: some View {
-    ForEach(LetterSpacing.allCases, id: \.rawValue) { space in
-      Text(space.rawValue).tracking(PBFont.body.space(space, font: .body))
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
+      ForEach(LetterSpacing.allCases, id: \.rawValue) { space in
+        Text(space.rawValue).tracking(PBFont.body.space(space, font: .body))
+      }
     }
   }
   
   var componentsText: some View {
-    VStack(alignment: .leading, spacing: Spacing.small) {
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
       Text("Button Text")
         .pbFont(.buttonText())
       Text("Badge Text")
@@ -79,7 +83,7 @@ private extension TypographyCatalog {
   }
   
   var caption: some View {
-    VStack(alignment: .leading, spacing: Spacing.small) {
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
       Text("Large Caption")
         .pbFont(.largeCaption)
       Text("Caption")
@@ -92,7 +96,7 @@ private extension TypographyCatalog {
   }
   
   var detail: some View {
-    VStack(alignment: .leading, spacing: Spacing.small) {
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
       Text("I am a detail kit")
         .pbFont(.detail(false))
       Text("I am a detail kit")
@@ -101,17 +105,11 @@ private extension TypographyCatalog {
   }
   
   var message: some View {
-    VStack(spacing: Spacing.none) {
+    VStack(alignment: .leading, spacing: Spacing.xSmall) {
       Text("Message Title")
         .pbFont(.messageTitle)
-      
-      Text("Message Body Message Body Message Body Message Body Message Body ")
+      Text("Message Body")
         .pbFont(.messageBody)
-        .background(GeometryReader(content: { geometry in
-          Color.pink.opacity(0.2).onAppear {
-            print("Size message body: \(geometry.size)")
-          }
-        }))
     }
   }
 }
@@ -119,4 +117,18 @@ private extension TypographyCatalog {
 #Preview {
   registerFonts()
   return TypographyCatalog()
+}
+
+extension View {
+  func sizeReader(_ title: String) -> some View {
+      self.background(GeometryReader(content: { geometry in
+        HStack {
+          Color.pink.opacity(0.2).onAppear {
+            print("Size of \(title): \nwidth: \(geometry.size.width), height: \(geometry.size.height)\n")
+          }
+          
+          Text("Height: \(String(format: "%.1f", geometry.size.height))").pbFont(.badgeText)
+        }
+      }))
+  }
 }

--- a/Sources/Playbook/Resources/Helper Files/Components.swift
+++ b/Sources/Playbook/Resources/Helper Files/Components.swift
@@ -90,14 +90,14 @@ public enum Components: String, CaseIterable {
     case .homeAddress: HomeAddressStreetCatalog()
     case .icon: IconCatalog()
     case .iconCircle: IconCircleCatalog()
-    case .image: PBImage_Previews.previews
-    case .label: PBLabelValue_Previews.previews
+    case .image: ImageCatalog()
+    case .label: LabelValueCatalog()
     case .loader: LoaderCatalog()
-    case .message: PBMessage_Previews.previews
+    case .message: MessageCatalog()
     case .multipleUser: MultipleUsersCatalog()
     case .multipleUsersIndicator: MultipleUsersIndicatorCatalog()
     case .multipleUserStacked: MultipleUsersStackedCatalog()
-    case .nav: PBNav_Previews.previews
+    case .nav: NavCatalog()
     case .person: PersonCatalog()
     case .personContact: PersonContactCatalog()
     case .pill: PillCatalog()
@@ -105,10 +105,10 @@ public enum Components: String, CaseIterable {
     case .progressIndicator: PBSpinner_Previews.previews
     case .radio: RadioCatalog()
     case .sectionSeparator: SectionSeparatorCatalog()
-    case .select: PBSelect_Previews.previews
+    case .select: SelectCatalog()
     case .tabBar: TabBarCatalog()
     case .textArea: TextAreaCatalog()
-    case .textInput: PBTextInput_Previews.previews
+    case .textInput: TextInputCatalog()
     case .tooltip: TooltipCatalog()
     case .time: TimeCatalog()
     case .timeStamp: TimeStampCatalog()


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fix Message kit font line-height(s), spacing, and layouts to match web

**Screenshots:** Screenshots to visualize your addition/change
OBS: The provided screenshots are for debugging purpose only. It is not applicable to the current app ui.

***iOS***
<img width="656" alt="Screenshot 2024-04-10 at 6 06 51 PM" src="https://github.com/powerhome/playbook-swift/assets/60269827/de225d27-2d53-400c-b95a-e49d2b1f9484">

***WEB***
<img width="569" alt="Screenshot 2024-04-10 at 6 09 57 PM" src="https://github.com/powerhome/playbook-swift/assets/60269827/7bfe1411-09ce-4d7e-9990-2ae26cfefd52">
<img width="695" alt="Screenshot 2024-04-10 at 6 13 14 PM" src="https://github.com/powerhome/playbook-swift/assets/60269827/a3edf29d-652d-4270-a15e-66fc108b36fc">


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change

### Checklist
- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
