### PR TITLE
[PBIOS-306] Fix cursor pointer and pills

### DIFF
--- a/Sources/Playbook/Components/Button/PBReactionButton.swift
+++ b/Sources/Playbook/Components/Button/PBReactionButton.swift
@@ -32,9 +32,7 @@ public struct PBReactionButton: View {
   public var body: some View {
     reactionButtonView
       .clipShape(Capsule())
-      .onHover(perform: { hovering in
-        isHovering = hovering
-      })
+      .onHover(disabled: false) { isHovering = $0 }
   }
 }
 

--- a/Sources/Playbook/Components/Nav/PBNav.swift
+++ b/Sources/Playbook/Components/Nav/PBNav.swift
@@ -43,7 +43,7 @@ public struct PBNav: View {
 
     return view
       .contentShape(Rectangle())
-      .onHover { hovering in
+      .onHover(disabled: false) { hovering in
         if hovering {
           currentHover = index
         } else if currentHover == index {

--- a/Sources/Playbook/Components/Popover/PBPopover.swift
+++ b/Sources/Playbook/Components/Popover/PBPopover.swift
@@ -87,7 +87,7 @@ extension Popover {
   private func updateView(_ frame: CGRect) {
     popoverManager.view = AnyView(
       view
-        .onHover { refreshView = $0 }
+        .onHover(disabled: false) { refreshView = $0 }
         .frame(width: width)
         .sizeReader { size in
           let popoverFrame = position.calculateFrame(from: offset(frame), size: size)

--- a/Sources/Playbook/Components/Popover/PopoverHandler.swift
+++ b/Sources/Playbook/Components/Popover/PopoverHandler.swift
@@ -62,6 +62,9 @@ struct GlobalPopoverView: View {
       break
     case .outside, .anywhere:
       onClose()
+      #if os(macOS)
+      NSCursor.pointingHand.set()
+      #endif
     }
   }
   

--- a/Sources/Playbook/Components/Text Input/PBTextInput.swift
+++ b/Sources/Playbook/Components/Text Input/PBTextInput.swift
@@ -59,7 +59,7 @@ public struct PBTextInput: View {
       .onTapGesture {
         selected = true
       }
-      .onHover { isHovering in
+      .onHover(disabled: false) { isHovering in
         self.isHovering = isHovering
       }
 

--- a/Sources/Playbook/Components/Toggle/PBRadioStyle.swift
+++ b/Sources/Playbook/Components/Toggle/PBRadioStyle.swift
@@ -45,7 +45,7 @@ public struct PBRadioStyle: ToggleStyle {
         }
         .buttonStyle(.borderless)
       }
-      .onHover { hovering in
+      .onHover(disabled: false) { hovering in
         withAnimation {
           isHovering = hovering
         }

--- a/Sources/Playbook/Components/Toggle/PBToggle.swift
+++ b/Sources/Playbook/Components/Toggle/PBToggle.swift
@@ -45,7 +45,7 @@ public struct PBToggle: View {
           .frame(width: 18, height: 18, alignment: .center)
           .offset(x: checked ? 11 : -11, y: 0)
       }
-      .onHover { hovering in
+      .onHover(disabled: false) { hovering in
         withAnimation {
           isHovering = hovering
         }

--- a/Sources/Playbook/Components/Toggle/PBToggleStyle.swift
+++ b/Sources/Playbook/Components/Toggle/PBToggleStyle.swift
@@ -40,7 +40,7 @@ public struct PBToggleStyle: ToggleStyle {
           .frame(width: 20, height: 20, alignment: .center)
           .offset(x: configuration.isOn ? 12 : -12, y: 0)
       }
-      .onHover { hovering in
+      .onHover(disabled: false) { hovering in
         withAnimation {
           isHovering = hovering
         }

--- a/Sources/Playbook/Components/Tooltip/PBTooltip.swift
+++ b/Sources/Playbook/Components/Tooltip/PBTooltip.swift
@@ -44,7 +44,7 @@ public struct PBTooltip: ViewModifier {
     HStack {
       if self.canPresent {
         content
-        .onHover(perform: handleOnHover)
+        .onHover(disabled: false) { handleOnHover(hovering: $0) }
         .onChange(of: shouldPresentPopover, perform: handleOnChange)
         .popover(isPresented: $presentPopover, arrowEdge: self.placement, content: popoverView)
       } else {

--- a/Sources/Playbook/Components/Typeahead/GridInputField.swift
+++ b/Sources/Playbook/Components/Typeahead/GridInputField.swift
@@ -86,7 +86,7 @@ public struct GridInputField: View {
     }
     .onHover {
       isHovering = $0
-      setupCursor
+      setupCursor(hover: $0)
     }
   }
 }
@@ -136,9 +136,9 @@ private extension GridInputField {
     }
   }
   
-  var setupCursor: Void {
+  func setupCursor(hover: Bool) {
     #if os(macOS)
-    if isHovering {
+    if hover {
       NSCursor.arrow.push()
     }
     else {
@@ -187,9 +187,8 @@ private extension GridInputField {
   var dismissIcon: some View {
     PBIcon(FontAwesome.times, size: .xSmall)
       .foregroundStyle(iconColor(on: clearButtonIsHovering))
-      .onHover {
+      .onHover(disabled: false) {
         clearButtonIsHovering = $0
-        setupCursor
         isHovering = true
       }
   }
@@ -201,9 +200,8 @@ private extension GridInputField {
   var indicatorView: some View {
     PBIcon(FontAwesome.chevronDown, size: .xSmall)
       .foregroundStyle(iconColor(on: indicatorIsHovering))
-      .onHover {
+      .onHover(disabled: false) {
         indicatorIsHovering = $0
-        setupCursor
         isHovering = true
       }
       .onTapGesture {

--- a/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
@@ -123,7 +123,7 @@ private extension PBTypeahead {
               .padding(.vertical, Spacing.xSmall + 4)
               .frame(maxWidth: .infinity, alignment: .leading)
               .background(listBackgroundColor(index))
-              .onHover { hover in
+              .onHover(disabled: false) { hover in
                 isHovering = hover
                 hoveringIndex = index
                 hoveringOption = result

--- a/Sources/Playbook/Components/Typeahead/Pill/TypeaheadPill.swift
+++ b/Sources/Playbook/Components/Typeahead/Pill/TypeaheadPill.swift
@@ -45,7 +45,7 @@ struct TypeaheadPill: View {
           .stroke(lineWidth: borderWidth)
           .foregroundStyle(borderColor)
       )
-      .onHover { hovering in
+      .onHover(disabled: false) { hovering in
         isHovering = hovering
       }
     }

--- a/Sources/Playbook/Resources/Extensions/OnHover.swift
+++ b/Sources/Playbook/Resources/Extensions/OnHover.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 
 extension View {
+  @inlinable
   func onHover(disabled: Bool, action: @escaping (Bool) -> Void) -> some View {
     return AnyView(
       self.onHover { hovering in

--- a/Sources/Playbook/Resources/Extensions/View+ReactionButtonStyle.swift
+++ b/Sources/Playbook/Resources/Extensions/View+ReactionButtonStyle.swift
@@ -32,7 +32,7 @@ struct ReactionButtonModifier: ViewModifier {
             .animation(.easeInOut(duration: 0.3), value: isHovering)
       )
       .clipShape(Capsule())
-      .onHover { hovering in
+      .onHover(disabled: false) { hovering in
       #if os(macOS)
         if hovering {
             NSCursor.pointingHand.push()

--- a/Sources/Playbook/Resources/Helper Files/Mocks.swift
+++ b/Sources/Playbook/Resources/Helper Files/Mocks.swift
@@ -18,7 +18,7 @@ enum Mocks {
   static let oneUser = [andrew]
   static let twoUsers = [andrew, ana]
   static let multipleUsers = [andrew, ana, patric, luccile]
-  static let multipleUsersDictionary: [(String, PBUser)] = [("Andrew", andrew), ("Ana", ana), ("Patric", patric), ("Luccile", luccile)]
+  static let multipleUsersDictionary: [(String, PBUser)] = [(andrew.name, andrew), (ana.name, ana), (patric.name, patric), (luccile.name, luccile)]
   static let avatarXSmall = PBAvatar(image: Image("andrew", bundle: .module), size: .xSmall)
   static let avatarXSmallStatus = PBAvatar(image: Image("andrew", bundle: .module), size: .xSmall, status: .online)
   static let userName = "Andrew Black"


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
- Cursor 'pointer' on hover/click of any option within dropdown (on macOS only)
- All user names in selected Pills match the original name from the dropdown option

**Screenshots:** Screenshots to visualize your addition/change
<img width="495" alt="Screenshot 2024-05-16 at 2 08 21 PM" src="https://github.com/powerhome/playbook-swift/assets/60269827/4c404290-7ab2-4bc1-a447-96d14a6bf141">


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change

### Checklist
- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
