### PR TITLE
[PBIOS-426] Checkbox dark mode fix

### DIFF
--- a/Sources/Playbook/Components/Checkbox/PBCheckboxStyle.swift
+++ b/Sources/Playbook/Components/Checkbox/PBCheckboxStyle.swift
@@ -55,7 +55,7 @@ public struct PBCheckboxStyle: ToggleStyle {
     switch (checkboxType, checked) {
     case (.default, true), (.error, true), (.indeterminate, true): return .pbPrimary
     case (.error, false): return .status(.error)
-    default: return Color.border
+    default: return Color.white
     }
   }
 


### PR DESCRIPTION
**What does this PR do?**
[PBIOS-426] Checkbox dark mode fix

**Screenshots:**
<img width="903" alt="Screenshot 2024-06-13 at 10 47 48 AM" src="https://github.com/powerhome/playbook-swift/assets/54749071/067013a2-b0ee-4143-8305-4b307e4988c6">

### Checklist
- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [x] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [x] **TESTING** - Have you tested your story?
