### PR TITLE
[PBIOS-460] Fix user kit name fonts

### DIFF
--- a/Sources/Playbook/Components/Button/PBButton.swift
+++ b/Sources/Playbook/Components/Button/PBButton.swift
@@ -19,6 +19,7 @@ public struct PBButton: View {
   var iconPosition: IconPosition?
   @Binding var isLoading: Bool
   let action: (() -> Void)?
+    @Environment(\.colorScheme) private var colorScheme
   
   public init(
     fullWidth: Bool = false,
@@ -49,7 +50,7 @@ public struct PBButton: View {
       HStack {
         icon
         if isLoading {
-          PBLoader(color: variant.foregroundColor)
+          PBLoader(color: variant.foregroundColor(colorScheme: colorScheme))
         } else {
           if let title = title, shape == .primary {
             Text(title)

--- a/Sources/Playbook/Components/Button/PBButtonStyle.swift
+++ b/Sources/Playbook/Components/Button/PBButtonStyle.swift
@@ -13,6 +13,7 @@ public struct PBButtonStyle: ButtonStyle {
   var variant: PBButton.Variant
   var size: PBButton.Size
   @State private var isHovering = false
+  @Environment(\.colorScheme) var colorScheme
 
   public init(
     variant: PBButton.Variant,
@@ -34,7 +35,8 @@ public struct PBButtonStyle: ButtonStyle {
           .backgroundAnimation(
             configuration: configuration,
             variant: variant,
-            isHovering: isHovering
+            isHovering: isHovering, 
+            colorScheme: colorScheme
           )
           .primaryVariantBrightness(
             isPrimaryVariant: isPrimaryVariant,
@@ -46,7 +48,8 @@ public struct PBButtonStyle: ButtonStyle {
         variant.foregroundAnimation(
           configuration: configuration,
           variant: variant,
-          isHovering: isHovering
+          isHovering: isHovering,
+          colorScheme: colorScheme
         )
       )
       .cornerRadius(5)

--- a/Sources/Playbook/Components/Button/PBButtonVariant.swift
+++ b/Sources/Playbook/Components/Button/PBButtonVariant.swift
@@ -65,7 +65,7 @@ public extension PBButton {
 
       #if os(macOS)
       if isPressed {
-        return variant.backgroundColor
+        return variant.backgroundColor(colorScheme: colorScheme)
       } else if isHovering {
         return variant.hoverBackgroundColor
       } else {
@@ -93,7 +93,7 @@ public extension PBButton {
       } else if isLinkVariant && isHovering {
         return .text(.default)
       } else {
-        return variant.foregroundColor
+        return variant.foregroundColor(colorScheme: colorScheme)
       }
       #else
       return isLinkVariant && isPressed 

--- a/Sources/Playbook/Components/Button/PBButtonVariant.swift
+++ b/Sources/Playbook/Components/Button/PBButtonVariant.swift
@@ -17,18 +17,19 @@ public extension PBButton {
     case disabled
 
     // Color configuations
-    public var backgroundColor: Color {
+      public func  backgroundColor(colorScheme: ColorScheme) -> Color {
       switch self {
-      case .secondary: return .pbPrimary.opacity(0.05)
+      case .secondary: return Color.Buttons.Secondary.background(colorScheme)
       case .link: return .clear
       case .disabled: return .status(.neutral).opacity(0.5)
       default: return .pbPrimary
       }
     }
 
-    public var foregroundColor: Color {
+      public func foregroundColor(colorScheme: ColorScheme) -> Color {
       switch self {
       case .primary: return .white
+      case .secondary: return Color.Buttons.Secondary.foreground(colorScheme)
       case .disabled: return .text(.default).opacity(0.5)
       default: return .pbPrimary
       }
@@ -57,7 +58,8 @@ public extension PBButton {
     public func backgroundAnimation(
       configuration: ButtonStyleConfiguration,
       variant: PBButton.Variant,
-      isHovering: Bool
+      isHovering: Bool, 
+      colorScheme: ColorScheme
     ) -> Color {
       let isPressed = configuration.isPressed
 
@@ -67,19 +69,20 @@ public extension PBButton {
       } else if isHovering {
         return variant.hoverBackgroundColor
       } else {
-        return variant.backgroundColor
+        return variant.backgroundColor(colorScheme: colorScheme)
       }
       #else
       return isPressed
       ? variant.mobilePressedBackgroundColor
-      : variant.backgroundColor
+      : variant.backgroundColor(colorScheme: colorScheme)
       #endif
     }
       
     public func foregroundAnimation(
       configuration: ButtonStyleConfiguration,
       variant: PBButton.Variant,
-      isHovering: Bool
+      isHovering: Bool,
+      colorScheme: ColorScheme
     ) -> Color {
       let isLinkVariant = variant == .link
       let isPressed = configuration.isPressed
@@ -93,9 +96,9 @@ public extension PBButton {
         return variant.foregroundColor
       }
       #else
-      return isLinkVariant && isPressed
+      return isLinkVariant && isPressed 
       ? .text(.default)
-      : variant.foregroundColor
+      : variant.foregroundColor(colorScheme: colorScheme)
       #endif
     }
   }

--- a/Sources/Playbook/Components/Button/PBCircleButtonStyle.swift
+++ b/Sources/Playbook/Components/Button/PBCircleButtonStyle.swift
@@ -13,6 +13,7 @@ public struct PBCircleButtonStyle: ButtonStyle {
   var variant: PBButton.Variant
   var size: PBButton.Size
   @State private var isHovering = false
+    @Environment(\.colorScheme) var colorScheme
 
   public func makeBody(configuration: Configuration) -> some View {
     let isPressed = configuration.isPressed
@@ -25,7 +26,7 @@ public struct PBCircleButtonStyle: ButtonStyle {
           .backgroundAnimation(
             configuration: configuration,
             variant: variant,
-            isHovering: isHovering
+            isHovering: isHovering, colorScheme: colorScheme
           )
           .primaryVariantBrightness(
             isPrimaryVariant: isPrimaryVariant,
@@ -37,7 +38,8 @@ public struct PBCircleButtonStyle: ButtonStyle {
         variant.foregroundAnimation(
           configuration: configuration,
           variant: variant,
-          isHovering: isHovering
+          isHovering: isHovering,
+          colorScheme: colorScheme
         )
       )
       .clipShape(Circle())

--- a/Sources/Playbook/Components/User/PBUser.swift
+++ b/Sources/Playbook/Components/User/PBUser.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 public struct PBUser: View {
     var name: String
+    var nameFont: Typography
     var image: Image?
     var orientation: Orientation = .horizontal
     var size: Size = .small
@@ -21,6 +22,7 @@ public struct PBUser: View {
     var displayAvatar: Bool = true
     public init(
         name: String = "",
+        nameFont: Typography = .init(font: .title3, variant: .bold),
         image: Image? = nil,
         orientation: Orientation = .horizontal,
         size: Size = .medium,
@@ -31,6 +33,7 @@ public struct PBUser: View {
         displayAvatar: Bool = true
     ) {
         self.name = name
+        self.nameFont = nameFont
         self.image = image
         self.orientation = orientation
         self.size = size
@@ -80,7 +83,7 @@ public extension PBUser {
     var contentView: some View {
         VStack(alignment: alignment, spacing: Spacing.none) {
             Text(name)
-                .pbFont(titleStyle, variant: .bold)
+                .pbFont(nameFont.font, variant: nameFont.variant)
                 .foregroundColor(.text(.default))
             bodyText.pbFont(.body, color: .text(.light))
             if let content = subtitle {

--- a/Sources/Playbook/Components/User/UserCatalog.swift
+++ b/Sources/Playbook/Components/User/UserCatalog.swift
@@ -16,36 +16,15 @@ public struct UserCatalog: View {
     
     public var body: some View {
         PBDocStack(title: "User") {
-            PBDoc(title: "Default") {
-                defaultView
-            }
-            
-            PBDoc(title: "With Territory") {
-                withTerritoryView
-            }
-            
-            PBDoc(title: "Text Only") {
-                textOnlyView
-            }
-            
-            PBDoc(title: "Horizontal Size") {
-                horizontalSizeView
-            }
-            
-            PBDoc(title: "Vertical Size") {
-                verticalSizeView
-            }
-            
-            PBDoc(title: "Subtitle") {
-                subtitleView
-            }
-            
-            PBDoc(title: "Block Content Subtitle") {
-                subtitleBlockContentView
-            }
-            PBDoc(title: "Presence Indicator") {
-                presenceIndicatorView
-            }
+            PBDoc(title: "Default") { defaultView }
+            PBDoc(title: "With Territory") { withTerritoryView }
+            PBDoc(title: "Text Only") { textOnlyView }
+            PBDoc(title: "Horizontal Size") { horizontalSizeView }
+            PBDoc(title: "Vertical Size") { verticalSizeView }
+            PBDoc(title: "Subtitle") { subtitleView }
+            PBDoc(title: "Block Content Subtitle") { subtitleBlockContentView }
+            PBDoc(title: "Presence Indicator") { presenceIndicatorView }
+            PBDoc(title: "Custom Title Font") { customFontsView }
         }
     }
 }
@@ -264,6 +243,39 @@ public extension UserCatalog {
                 PBContact(type: contact.type, value: contact.contactValue, detail: contact.detail)
             }
         )
+    }
+    
+    var customFontsView: some View {
+        return Stack {
+            PBUser(
+                name: name,
+                nameFont: .init(font: .title3, variant: .light),
+                image: img,
+                orientation: .vertical,
+                size: .large,
+                title: title
+            )
+            PBUser(
+                name: name,
+                nameFont: .init(font: .title2, variant: .light),
+                image: img,
+                size: .small,
+                title: title
+            )
+            VStack {
+                PBUser(
+                    name: name,
+                    nameFont: .init(font: .title4, variant: .light),
+                    image: img,
+                    size: .small
+                )
+                PBUser(
+                    name: name,
+                    nameFont: .init(font: .body, variant: .light),
+                    size: .small
+                )
+            }
+        }
     }
 }
 

--- a/Sources/Playbook/Design Elements/Colors/Color.swift
+++ b/Sources/Playbook/Design Elements/Colors/Color.swift
@@ -162,8 +162,21 @@ public extension Color {
 }
 
 public extension Color {
-  init(hex: String) {
-    let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+    enum Buttons {
+        enum Secondary {
+            static func background(_ colorScheme: ColorScheme) -> Color {
+                return colorScheme == .light ? .pbPrimary.opacity(0.05) : Color(hex: "#fff").opacity(0.2)
+            }
+            static func foreground(_ colorScheme: ColorScheme) -> Color {
+                return colorScheme == .light ? .pbPrimary : .white
+            }
+        }
+    }
+}
+
+public extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
     var int: UInt64 = 0
     Scanner(string: hex).scanHexInt64(&int)
     let a, r, g, b: UInt64

--- a/Sources/Playbook/Design Elements/Typography/Typography.swift
+++ b/Sources/Playbook/Design Elements/Typography/Typography.swift
@@ -14,6 +14,16 @@ public struct Typography: ViewModifier {
   var variant: Variant
   var color: Color?
 
+    public init(
+        font: PBFont,
+        variant: Variant,
+        color: Color? = nil
+    ) {
+        self.font = font
+        self.variant = variant
+        self.color = color
+    }
+
   public func body(content: Content) -> some View {
     content
       .font(font.font)


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
We recently changed the User kit to make all the name font bold. The problem is that Connect uses the light variant for the name. 

OBS: this story fix this problem allowing the user to pass a custom font for the kit, but we need to discuss with the team if we really want this change or not. 



**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change

### Checklist
- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
