### PR TITLE
[PBIOS-461]Update Neutral Color

### DIFF
--- a/Sources/Playbook/Components/Pill/PBPill.swift
+++ b/Sources/Playbook/Components/Pill/PBPill.swift
@@ -44,7 +44,7 @@ public extension PBPill {
       case .primary: return .pbPrimary
       case .success: return .status(.success)
       case .warning: return .status(.warning)
-      default: return .status(.neutral)
+      default: return .text(.light)
       }
     }
 

--- a/Sources/Playbook/Design Elements/Colors/Color.xcassets/Status/Neutral.colorset/Contents.json
+++ b/Sources/Playbook/Design Elements/Colors/Color.xcassets/Status/Neutral.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "135",
-          "green" : "120",
-          "red" : "104"
+          "blue" : "214",
+          "green" : "205",
+          "red" : "193"
         }
       },
       "idiom" : "universal"

--- a/Sources/Playbook/Design Elements/Colors/Color.xcassets/Status/Neutral.colorset/Contents.json
+++ b/Sources/Playbook/Design Elements/Colors/Color.xcassets/Status/Neutral.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "214",
-          "green" : "205",
-          "red" : "193"
+          "blue" : "135",
+          "green" : "120",
+          "red" : "104"
         }
       },
       "idiom" : "universal"

--- a/Sources/Playbook/Design Elements/Colors/Color.xcassets/Status/Warning.colorset/Contents.json
+++ b/Sources/Playbook/Design Elements/Colors/Color.xcassets/Status/Warning.colorset/Contents.json
@@ -6,8 +6,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0x00",
-          "green" : "0xBB",
-          "red" : "0xF9"
+          "green" : "0x95",
+          "red" : "0xC6"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
**What does this PR do?** 
[PBIOS-461]Update Neutral Color

**Screenshots:** 
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-15 at 14 24 58](https://github.com/user-attachments/assets/ed5d9a97-1b49-4e03-95d4-3d72dbc87012)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-15 at 14 25 04](https://github.com/user-attachments/assets/37db41ea-3f8c-4ad3-ab5b-68891c27d7af)

### Checklist
- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [x] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [x] **TESTING** - Have you tested your story?
