### PR TITLE
[FVR-299] Start inheriting Power Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
   "extends": [
     "config:base",
     ":dependencyDashboard",
-    "group:allNonMajor"
+    "group:allNonMajor",
+    "github>powerhome/renovate-config"
   ],
-  "labels": ["dependencies"],
   "lockFileMaintenance": {
     "enabled": true
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "extends": [
-    "config:base",
-    ":dependencyDashboard",
-    "group:allNonMajor",
     "github>powerhome/renovate-config"
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Part of [FVR-299](https://runway.powerhrg.com/backlog_items/FVR-299)

This will ensure Power-standard Renovate config options like tagging Renovate PRs with the 'dependencies' label, ignoring updates to the `.github/workflows/stale.yml` file, and other important Renovate config options are respected in this repository.

This includes removing the config entry to tag PRs with 'dependencies', as this will be inherited from the parent config.