### PR TITLE
[RANGR-900] Create Beta Bundle ID and setting correct profile

### DIFF
--- a/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
+++ b/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
@@ -356,6 +356,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Playbook Showcase App Beta";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Playbook Showcase App Beta";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -396,7 +397,7 @@
 				MARKETING_VERSION = 6.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "Playbook Showcase Beta Dev ID";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Playbook Showcase Beta Dev ID";
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -469,6 +470,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Playbook Showcase App";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Playbook Showcase App";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
+++ b/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
@@ -275,6 +275,136 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		B5E69AF82D591F8A00F35C92 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Beta;
+		};
+		B5E69AF92D591F8A00F35C92 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution: Power Home Remodeling Group, LLC";
+				CODE_SIGN_STYLE = Manual;
+				CURRENT_PROJECT_VERSION = 135.1;
+				DEVELOPMENT_ASSET_PATHS = "\"PlaybookShowcase/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = EG5Q7XM634;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Playbook;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 6.6.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase.dev;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "Playbook In House";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Playbook Showcase App Beta";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Beta;
+		};
+		B5E69AFA2D591F8A00F35C92 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_ENTITLEMENTS = "PlaybookShowcase-macOS/PlaybookShowcase_macOS.entitlements";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 142.1;
+				DEVELOPMENT_ASSET_PATHS = "\"PlaybookShowcase/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = EG5Q7XM634;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = Playbook;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.6;
+				MARKETING_VERSION = 6.6.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase.dev;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "Playbook Showcase Beta Dev ID";
+				SDKROOT = macosx;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Beta;
+		};
 		F905153929F03B0800F9B66D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -299,7 +429,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 6.6.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
+				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -377,7 +507,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
 				MARKETING_VERSION = 6.6.3;
-				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
+				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
@@ -541,6 +671,7 @@
 			buildConfigurations = (
 				F905153929F03B0800F9B66D /* Debug */,
 				F905153A29F03B0800F9B66D /* Release */,
+				B5E69AF92D591F8A00F35C92 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -550,6 +681,7 @@
 			buildConfigurations = (
 				F905156929F03B3D00F9B66D /* Debug */,
 				F905156A29F03B3D00F9B66D /* Release */,
+				B5E69AFA2D591F8A00F35C92 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -559,6 +691,7 @@
 			buildConfigurations = (
 				F9370FF529EDCC0200FFD0DF /* Debug */,
 				F9370FF629EDCC0200FFD0DF /* Release */,
+				B5E69AF82D591F8A00F35C92 /* Beta */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
+++ b/PlaybookShowcase/PlaybookShowcase.xcodeproj/project.pbxproj
@@ -355,8 +355,7 @@
 				MARKETING_VERSION = 6.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Playbook In House";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Playbook Showcase App Beta";
+				PROVISIONING_PROFILE_SPECIFIER = "Playbook Showcase App Beta";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -469,8 +468,7 @@
 				MARKETING_VERSION = 6.6.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.powerhrg.PlaybookShowcase;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "Playbook In House";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Playbook Showcase App";
+				PROVISIONING_PROFILE_SPECIFIER = "Playbook Showcase App";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,6 +47,14 @@ lane :build_ios do |opts|
   export_method = 'enterprise'
   target = target_ios(opts[:suffix])
 
+  provisioningProfileBundle = "com.powerhrg.PlaybookShowcase"
+  provisioningProfileName = "Playbook Showcase App"
+
+  if opts[:suffix] == 'beta'
+    provisioningProfileBundle = "com.powerhrg.PlaybookShowcase.dev"
+    provisioningProfileName = "Playbook Showcase App Beta"
+  end
+
   gym(
     project: project,
     scheme: target,
@@ -56,7 +64,12 @@ lane :build_ios do |opts|
     build_path: build_path,
     derived_data_path: derived_data_path,
     xcargs: '-skipPackagePluginValidation -skipMacroValidation',
-    xcconfig: './PlaybookShowcase/Versioning.xcconfig'
+    xcconfig: './PlaybookShowcase/Versioning.xcconfig',
+    export_options: {
+      provisioningProfiles: {
+        provisioningProfileBundle => provisioningProfileName
+      }
+    }
   )
 end
 
@@ -65,6 +78,14 @@ lane :build_macos do |opts|
 
   export_method = 'developer-id'
   target = target_macos(opts[:suffix])
+
+  provisioningProfileBundle = "com.powerhrg.PlaybookShowcase"
+  provisioningProfileName = "Playbook Showcase App"
+
+  if opts[:suffix] == 'beta'
+    provisioningProfileBundle = "com.powerhrg.PlaybookShowcase.dev"
+    provisioningProfileName = "Playbook Showcase App Beta"
+  end
 
   gym(
     project: project,
@@ -76,7 +97,12 @@ lane :build_macos do |opts|
     build_path: build_path,
     derived_data_path: derived_data_path,
     xcargs: '-skipPackagePluginValidation -skipMacroValidation',
-    xcconfig: './PlaybookShowcase/Versioning.xcconfig'
+    xcconfig: './PlaybookShowcase/Versioning.xcconfig',
+    export_options: {
+      provisioningProfiles: {
+        provisioningProfileBundle => provisioningProfileName
+      }
+    }
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,7 +47,10 @@ lane :build_ios do |opts|
   export_method = 'enterprise'
   target = target_ios(opts[:suffix])
 
+  configuration = opts[:suffix] == "beta" ? "Beta" : "Release" 
+
   gym(
+    configuration: configuration,
     project: project,
     scheme: target,
     skip_package_dependencies_resolution: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,14 +47,6 @@ lane :build_ios do |opts|
   export_method = 'enterprise'
   target = target_ios(opts[:suffix])
 
-  provisioningProfileBundle = "com.powerhrg.PlaybookShowcase"
-  provisioningProfileName = "Playbook Showcase App"
-
-  if opts[:suffix] == 'beta'
-    provisioningProfileBundle = "com.powerhrg.PlaybookShowcase.dev"
-    provisioningProfileName = "Playbook Showcase App Beta"
-  end
-
   gym(
     project: project,
     scheme: target,
@@ -64,12 +56,7 @@ lane :build_ios do |opts|
     build_path: build_path,
     derived_data_path: derived_data_path,
     xcargs: '-skipPackagePluginValidation -skipMacroValidation',
-    xcconfig: './PlaybookShowcase/Versioning.xcconfig',
-    export_options: {
-      provisioningProfiles: {
-        provisioningProfileBundle => provisioningProfileName
-      }
-    }
+    xcconfig: './PlaybookShowcase/Versioning.xcconfig'
   )
 end
 
@@ -78,14 +65,6 @@ lane :build_macos do |opts|
 
   export_method = 'developer-id'
   target = target_macos(opts[:suffix])
-
-  provisioningProfileBundle = "com.powerhrg.PlaybookShowcase"
-  provisioningProfileName = "Playbook Showcase App"
-
-  if opts[:suffix] == 'beta'
-    provisioningProfileBundle = "com.powerhrg.PlaybookShowcase.dev"
-    provisioningProfileName = "Playbook Showcase App Beta"
-  end
 
   gym(
     project: project,
@@ -97,12 +76,7 @@ lane :build_macos do |opts|
     build_path: build_path,
     derived_data_path: derived_data_path,
     xcargs: '-skipPackagePluginValidation -skipMacroValidation',
-    xcconfig: './PlaybookShowcase/Versioning.xcconfig',
-    export_options: {
-      provisioningProfiles: {
-        provisioningProfileBundle => provisioningProfileName
-      }
-    }
+    xcconfig: './PlaybookShowcase/Versioning.xcconfig'
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -44,7 +44,7 @@ end
 desc "Build iOS"
 lane :build_ios do |opts|
 
-  export_method = 'enterprise'
+  export_method = 'ad-hoc'
   target = target_ios(opts[:suffix])
 
   configuration = opts[:suffix] == "beta" ? "Beta" : "Release" 

--- a/script_install_dependencies.sh
+++ b/script_install_dependencies.sh
@@ -17,7 +17,18 @@ check_install swiftformat
 # asdf dependencies
 asdf plugin add ruby
 asdf plugin update ruby
-while read -r line; do asdf install $line; done < .tool-versions
+
+# Install or update the versions specified in .tool-versions
+while read -r plugin version; do
+  if ! asdf list $plugin | grep -q "$version"; then
+    echo "Installing $plugin $version..."
+    asdf install $plugin $version
+  else
+    echo "$plugin $version is already installed. Skipping."
+  fi
+done < .tool-versions
+
+# Reshim to reflect any changes
 asdf reshim
 
 # bundler


### PR DESCRIPTION
Task on Runway [RANGR-900](https://nitro.powerhrg.com/runway/backlog_items/RANGR-900)

Excalibur will infer the name and level of the apps based on unique bundle IDs, so I had to adjust NMC to have a different bundle ID for Beta and Developer.

The new bundle IDs are:
com.powerhrg.PlaybookShowcase.dev;
com.powerhrg.PlaybookShowcase is now reserved only for Production.