### PR TITLE
[PBIOS-695]Typeahead Add Custom Option for No Options

### DIFF
--- a/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
@@ -66,7 +66,7 @@ public extension PBTypeahead {
         }
     }
 
-    func listItemView(option: PBTypeahead.Option, index: Int) -> some View {
+  func listItemView(option: PBTypeahead.Option, index: Int) -> some View {
         HStack {
             if option.text == viewModel.noOptionsText {
                 emptyView
@@ -95,14 +95,12 @@ public extension PBTypeahead {
     }
 
     var emptyView: some View {
-        HStack {
-            Spacer()
-            Text(viewModel.noOptionsText)
-                .pbFont(.body, color: .text(.light))
-            Spacer()
+        VStack {
+          noOptionsText()
         }
         .padding(.horizontal, Spacing.xSmall + 4)
         .padding(.vertical, Spacing.xSmall + 4)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
     func listBackgroundColor(_ index: Int?) -> Color {
@@ -113,11 +111,11 @@ public extension PBTypeahead {
                 }
             default: break
         }
-#if os(macOS)
+        #if os(macOS)
         return viewModel.hoveringIndex == index ? .hover : .card
-#elseif os(iOS)
+        #elseif os(iOS)
         return .card
-#endif
+        #endif
     }
 
     func listTextolor(_ index: Int?) -> Color {

--- a/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
@@ -24,14 +24,16 @@ public struct PBTypeahead: View {
   internal let disableFiltering: Bool
   internal let disableKeyboardHandler: Bool
 
+  var noOptionsText: () -> AnyView?
+
   @State internal var selectedInputOptions: GridInputField.Selection
   @Binding internal var selectedOptions: [PBTypeahead.Option]
   @Binding internal var searchText: String
   @FocusState.Binding internal var isFocused: Bool
 
-  #if os(macOS)
+#if os(macOS)
   @StateObject private var keyboardHandler = TypeaheadKeyboardHandler()
-  #endif
+#endif
 
   public init(
     id: Int,
@@ -47,7 +49,13 @@ public struct PBTypeahead: View {
     selectedOptions: Binding<[PBTypeahead.Option]>,
     clearAction: (() -> Void)? = nil,
     disableFiltering: Bool = false,
-    disableKeyboardHandler: Bool = false
+    disableKeyboardHandler: Bool = false,
+
+    @ViewBuilder noOptionsText: @escaping () -> some View = {
+      Text("No Options")
+        .pbFont(.body, color: .text(.light))
+    }
+    
   ) {
     self.id = id
     self.title = title
@@ -67,6 +75,7 @@ public struct PBTypeahead: View {
       placeholder: placeholder
     ))
     self.disableKeyboardHandler = disableKeyboardHandler
+    self.noOptionsText = { AnyView(noOptionsText()) }
   }
 
   public var body: some View {
@@ -87,7 +96,7 @@ public struct PBTypeahead: View {
         clearAction: clearAction,
         disableFiltering: disableFiltering
       )
-      
+
       #if os(macOS)
       if !disableKeyboardHandler {
         keyboardHandler.delegate = viewModel

--- a/Sources/Playbook/Components/Typeahead/PBTypeaheadViewModel.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeaheadViewModel.swift
@@ -25,8 +25,8 @@ final class PBTypeaheadViewModel: ObservableObject {
     private var disableFiltering: Bool
     
     // Constants
-    private(set) var noOptionsText = "No options"
-    
+    private(set) var noOptionsText = ""
+
     // State Publishers
     var optionsSubject: CurrentValueSubject<[PBTypeahead.Option], Never>!
     private let searchTermSubject = PassthroughSubject<String, Never>()
@@ -259,7 +259,7 @@ final class PBTypeaheadViewModel: ObservableObject {
         
         let emptyStateOption = PBTypeahead.Option(
             id: "",
-            text: noOptionsText,
+            text: "",
             customView: nil
         )
         

--- a/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
+++ b/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
@@ -140,9 +140,9 @@ extension TypeaheadCatalog {
     .presentationMode(isPresented: $presentDialog) {
       DialogView(isPresented: $presentDialog)
         .popoverHandler(id: 5)
-#if os(macOS)
+        #if os(macOS)
         .frame(minWidth: 500, minHeight: 390)
-#endif
+        #endif
     }
   }
 

--- a/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
+++ b/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
@@ -10,171 +10,171 @@
 import SwiftUI
 
 public struct TypeaheadCatalog: View {
-    private var assetsColors = Mocks.assetsColors
-    @State private var searchTextColors: String = ""
-    @State private var selectedColors: [PBTypeahead.Option] = [Mocks.assetsColors[2]]
-    @FocusState private var isFocusedColors
-
-    private var assetsUsers = Mocks.assetesMultipleUsers
-    @State private var searchTextUsers: String = ""
-    @State private var selectedUsers: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[0], Mocks.assetesMultipleUsers[1]]
-    @FocusState private var isFocusedUsers
-
-    @State private var searchTextHeight: String = ""
-    @State private var selectedHeight: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[3], Mocks.assetesMultipleUsers[2]]
-    @FocusState private var isFocusedHeight
-
-    private var assetsSection: [PBTypeahead.OptionType] = Mocks.assetsSectionUsers
-    @State private var searchTextSections: String = ""
-    @State private var selectedSections: [PBTypeahead.Option] = []
-    @FocusState private var isFocusedSection
-
-    @State private var presentDialog: Bool = false
-    private var popoverManager = PopoverManager.shared
-
-    public var body: some View {
-        PBDocStack(title: "Typeahead") {
-            PBDoc(title: "Default", spacing: Spacing.small) { colors }
-            PBDoc(title: "With Pills", spacing: Spacing.small) { users }
+  private var assetsColors = Mocks.assetsColors
+  @State private var searchTextColors: String = ""
+  @State private var selectedColors: [PBTypeahead.Option] = [Mocks.assetsColors[2]]
+  @FocusState private var isFocusedColors
+  
+  private var assetsUsers = Mocks.assetesMultipleUsers
+  @State private var searchTextUsers: String = ""
+  @State private var selectedUsers: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[0], Mocks.assetesMultipleUsers[1]]
+  @FocusState private var isFocusedUsers
+  
+  @State private var searchTextHeight: String = ""
+  @State private var selectedHeight: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[3], Mocks.assetesMultipleUsers[2]]
+  @FocusState private var isFocusedHeight
+  
+  private var assetsSection: [PBTypeahead.OptionType] = Mocks.assetsSectionUsers
+  @State private var searchTextSections: String = ""
+  @State private var selectedSections: [PBTypeahead.Option] = []
+  @FocusState private var isFocusedSection
+  
+  @State private var presentDialog: Bool = false
+  private var popoverManager = PopoverManager.shared
+  
+  public var body: some View {
+    PBDocStack(title: "Typeahead") {
+      PBDoc(title: "Default", spacing: Spacing.small) { colors }
+      PBDoc(title: "With Pills", spacing: Spacing.small) { users }
 #if os(macOS)
-            PBDoc(title: "Dialog") { dialog }
+      PBDoc(title: "Dialog") { dialog }
 #endif
-            PBDoc(title: "Height Adjusted Dropdown", spacing: Spacing.small) { heightAdjusted }
-            PBDoc(title: "Sections", spacing: Spacing.small) { sections }
-                .padding(.bottom, 500)
-        }
-        .scrollDismissesKeyboard(.immediately)
-        .onTapGesture {
-            dismissFocus()
-        }
-        .popoverHandler(id: 1)
-        .popoverHandler(id: 2)
-        .popoverHandler(id: 3)
-        .popoverHandler(id: 4)
+      PBDoc(title: "Height Adjusted Dropdown", spacing: Spacing.small) { heightAdjusted }
+      PBDoc(title: "Sections", spacing: Spacing.small) { sections }
+        .padding(.bottom, 500)
     }
+    .scrollDismissesKeyboard(.immediately)
+    .onTapGesture {
+      dismissFocus()
+    }
+    .popoverHandler(id: 1)
+    .popoverHandler(id: 2)
+    .popoverHandler(id: 3)
+    .popoverHandler(id: 4)
+  }
 }
 
 extension TypeaheadCatalog {
-    var colors: some View {
-        PBTypeahead(
-            id: 1,
-            title: "Colors",
-            searchText: $searchTextColors,
-            options: assetsColors,
-            selection: .single,
-            isFocused: $isFocusedColors,
-            selectedOptions: $selectedColors
-        )
+  var colors: some View {
+    PBTypeahead(
+      id: 1,
+      title: "Colors",
+      searchText: $searchTextColors,
+      options: assetsColors,
+      selection: .single,
+      isFocused: $isFocusedColors,
+      selectedOptions: $selectedColors
+    )
+  }
+  
+  var users: some View {
+    PBTypeahead(
+      id: 2,
+      title: "Users",
+      placeholder: "type the name of a user",
+      searchText: $searchTextUsers,
+      options: assetsUsers,
+      selection: .multiple(variant: .pill),
+      isFocused: $isFocusedUsers,
+      selectedOptions: $selectedUsers
+    )
+  }
+  
+  var heightAdjusted: some View {
+    PBTypeahead(
+      id: 3,
+      title: "Users",
+      placeholder: "type the name of a user",
+      searchText: $searchTextHeight,
+      options: assetsUsers,
+      selection: .multiple(variant: .pill),
+      dropdownMaxHeight: 150,
+      isFocused: $isFocusedHeight,
+      selectedOptions: $selectedHeight
+    )
+  }
+  
+  var sections: some View {
+    PBTypeaheadTemplate(
+      id: 4,
+      title: "Sections",
+      searchText: $searchTextSections,
+      options: assetsSection,
+      selection: .multiple(variant: .pill),
+      dropdownMaxHeight: 400,
+      isFocused: $isFocusedSection,
+      selectedOptions: $selectedSections
+    )
+  }
+  
+  var dialog: some View {
+    PBButton(title: "Simple") {
+      DialogCatalog.disableAnimation()
+      presentDialog.toggle()
     }
-
-    var users: some View {
-        PBTypeahead(
-            id: 2,
+    .presentationMode(isPresented: $presentDialog) {
+      DialogView(isPresented: $presentDialog)
+        .popoverHandler(id: 5)
+        #if os(macOS)
+        .frame(minWidth: 500, minHeight: 390)
+        #endif
+    }
+  }
+  
+  func closeToast() {
+    presentDialog = false
+  }
+  
+  struct DialogView: View {
+    @Binding var isPresented: Bool
+    @State private var isLoading: Bool = false
+    @State private var searchTextUsers: String = ""
+    @State private var assetsUsers = Mocks.assetesMultipleUsers
+    @State private var selectedUsers: [PBTypeahead.Option] = [
+      Mocks.assetesMultipleUsers[0],
+      Mocks.assetesMultipleUsers[1]
+    ]
+    @FocusState var isFocused
+    
+    var body: some View {
+      PBDialog(title: "Dialog",
+               variant: .default,
+               onClose: { isPresented = false },
+               shouldCloseOnOverlay: false) {
+        VStack {
+          PBTypeahead(
+            id: 5,
             title: "Users",
             placeholder: "type the name of a user",
             searchText: $searchTextUsers,
             options: assetsUsers,
             selection: .multiple(variant: .pill),
-            isFocused: $isFocusedUsers,
+            dropdownMaxHeight: 300,
+            isFocused: $isFocused,
             selectedOptions: $selectedUsers
-        )
-    }
-
-    var heightAdjusted: some View {
-        PBTypeahead(
-            id: 3,
-            title: "Users",
-            placeholder: "type the name of a user",
-            searchText: $searchTextHeight,
-            options: assetsUsers,
-            selection: .multiple(variant: .pill),
-            dropdownMaxHeight: 150,
-            isFocused: $isFocusedHeight,
-            selectedOptions: $selectedHeight
-        )
-    }
-
-    var sections: some View {
-        PBTypeaheadTemplate(
-            id: 4,
-            title: "Sections",
-            searchText: $searchTextSections,
-            options: assetsSection,
-            selection: .multiple(variant: .pill),
-            dropdownMaxHeight: 400,
-            isFocused: $isFocusedSection,
-            selectedOptions: $selectedSections
-        )
-    }
-
-    var dialog: some View {
-        PBButton(title: "Simple") {
-            DialogCatalog.disableAnimation()
-            presentDialog.toggle()
+          )
+          Spacer()
         }
-        .presentationMode(isPresented: $presentDialog) {
-            DialogView(isPresented: $presentDialog)
-                .popoverHandler(id: 5)
-#if os(macOS)
-                .frame(minWidth: 500, minHeight: 390)
-#endif
+        .padding(Spacing.medium)
+        .background(Color.white.opacity(0.01))
+        .onTapGesture {
+          isFocused = false
         }
+      }
     }
-
-    func closeToast() {
-        presentDialog = false
+  }
+  
+  func dismissFocus() {
+    isFocusedColors = false
+    isFocusedUsers = false
+    isFocusedHeight = false
+    isFocusedSection = false
+    Task {
+      await popoverManager.dismissPopovers()
     }
-
-    struct DialogView: View {
-        @Binding var isPresented: Bool
-        @State private var isLoading: Bool = false
-        @State private var searchTextUsers: String = ""
-        @State private var assetsUsers = Mocks.assetesMultipleUsers
-        @State private var selectedUsers: [PBTypeahead.Option] = [
-            Mocks.assetesMultipleUsers[0],
-            Mocks.assetesMultipleUsers[1]
-        ]
-        @FocusState var isFocused
-
-        var body: some View {
-            PBDialog(title: "Dialog",
-                     variant: .default,
-                     onClose: { isPresented = false },
-                     shouldCloseOnOverlay: false) {
-                VStack {
-                    PBTypeahead(
-                        id: 5,
-                        title: "Users",
-                        placeholder: "type the name of a user",
-                        searchText: $searchTextUsers,
-                        options: assetsUsers,
-                        selection: .multiple(variant: .pill),
-                        dropdownMaxHeight: 300,
-                        isFocused: $isFocused,
-                        selectedOptions: $selectedUsers
-                    )
-                    Spacer()
-                }
-                .padding(Spacing.medium)
-                .background(Color.white.opacity(0.01))
-                .onTapGesture {
-                    isFocused = false
-                }
-            }
-        }
-    }
-
-    func dismissFocus() {
-        isFocusedColors = false
-        isFocusedUsers = false
-        isFocusedHeight = false
-        isFocusedSection = false
-        Task {
-            await popoverManager.dismissPopovers()
-        }
-    }
+  }
 }
 
 #Preview {
-    TypeaheadCatalog()
+  TypeaheadCatalog()
 }

--- a/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
+++ b/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
@@ -18,6 +18,7 @@ public struct TypeaheadCatalog: View {
   private var assetsUsers = Mocks.assetesMultipleUsers
   @State private var searchTextUsers: String = ""
   @State private var selectedUsers: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[0], Mocks.assetesMultipleUsers[1]]
+  @State private var selectedUsersNoOptions: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[0], Mocks.assetesMultipleUsers[1]]
   @State private var selectedNoOptions: String = ""
   @FocusState private var isFocusedUsers
   @FocusState private var isFocusedUsersNoOptions
@@ -117,16 +118,16 @@ extension TypeaheadCatalog {
       title: "Users",
       placeholder: "type the name of a user",
       searchText: $selectedNoOptions,
-      options: [],
+      options: assetsUsers,
       selection: .multiple(variant: .pill),
       isFocused: $isFocusedUsersNoOptions,
-      selectedOptions: $selectedUsers,
+      selectedOptions: $selectedUsersNoOptions,
       noOptionsText: {
         HStack(spacing: Spacing.none) {
           Text("No results found. Review address for accuracy or ")
           PBButton(variant: .link, title: "add address.")
         }
-        .pbFont(.body, color: .text(.light))
+        .pbFont(.detail(false), color: .text(.light))
       }
     )
   }

--- a/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
+++ b/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
@@ -40,9 +40,9 @@ public struct TypeaheadCatalog: View {
       PBDoc(title: "Default", spacing: Spacing.small) { colors }
       PBDoc(title: "With Pills", spacing: Spacing.small) { users }
       PBDoc(title: "No Options", spacing: Spacing.small) { noOptions }
-      #if os(macOS)
+#if os(macOS)
       PBDoc(title: "Dialog") { dialog }
-      #endif
+#endif
       PBDoc(title: "Height Adjusted Dropdown", spacing: Spacing.small) { heightAdjusted }
       PBDoc(title: "Sections", spacing: Spacing.small) { sections }
         .padding(.bottom, 500)

--- a/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
+++ b/Sources/Playbook/Components/Typeahead/TypeaheadCatalog.swift
@@ -18,7 +18,9 @@ public struct TypeaheadCatalog: View {
   private var assetsUsers = Mocks.assetesMultipleUsers
   @State private var searchTextUsers: String = ""
   @State private var selectedUsers: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[0], Mocks.assetesMultipleUsers[1]]
+  @State private var selectedNoOptions: String = ""
   @FocusState private var isFocusedUsers
+  @FocusState private var isFocusedUsersNoOptions
 
   @State private var searchTextHeight: String = ""
   @State private var selectedHeight: [PBTypeahead.Option] = [Mocks.assetesMultipleUsers[3], Mocks.assetesMultipleUsers[2]]
@@ -36,9 +38,10 @@ public struct TypeaheadCatalog: View {
     PBDocStack(title: "Typeahead") {
       PBDoc(title: "Default", spacing: Spacing.small) { colors }
       PBDoc(title: "With Pills", spacing: Spacing.small) { users }
-#if os(macOS)
+      PBDoc(title: "No Options", spacing: Spacing.small) { noOptions }
+      #if os(macOS)
       PBDoc(title: "Dialog") { dialog }
-#endif
+      #endif
       PBDoc(title: "Height Adjusted Dropdown", spacing: Spacing.small) { heightAdjusted }
       PBDoc(title: "Sections", spacing: Spacing.small) { sections }
         .padding(.bottom, 500)
@@ -51,6 +54,7 @@ public struct TypeaheadCatalog: View {
     .popoverHandler(id: 2)
     .popoverHandler(id: 3)
     .popoverHandler(id: 4)
+    .popoverHandler(id: 5)
   }
 }
 
@@ -94,7 +98,6 @@ extension TypeaheadCatalog {
     )
   }
 
-
   var sections: some View {
     PBTypeaheadTemplate(
       id: 4,
@@ -105,6 +108,26 @@ extension TypeaheadCatalog {
       dropdownMaxHeight: 400,
       isFocused: $isFocusedSection,
       selectedOptions: $selectedSections
+    )
+  }
+
+  var noOptions: some View {
+    PBTypeahead(
+      id: 5,
+      title: "Users",
+      placeholder: "type the name of a user",
+      searchText: $selectedNoOptions,
+      options: [],
+      selection: .multiple(variant: .pill),
+      isFocused: $isFocusedUsersNoOptions,
+      selectedOptions: $selectedUsers,
+      noOptionsText: {
+        HStack(spacing: Spacing.none) {
+          Text("No results found. Review address for accuracy or ")
+          PBButton(variant: .link, title: "add address.")
+        }
+        .pbFont(.body, color: .text(.light))
+      }
     )
   }
 


### PR DESCRIPTION
**What does this PR do?** 

[PBIOS-695]Typeahead Add Custom Option for No Options

https://runway.powerhrg.com/backlog_items/PBIOS-695

**Screenshots:** 
![Screenshot 2025-02-25 at 1 56 30 PM](https://github.com/user-attachments/assets/0d91744a-69f4-4c6f-90f4-3332cc42a7c8)


### Checklist
- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [x] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [x] **TESTING** - Have you tested your story?
