### PR TITLE
[PBIOS-681] Typeahead backspace delete action on iOS

### DIFF
--- a/PlaybookShowcase/PlaybookShowcase/Mocks.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Mocks.swift
@@ -7,7 +7,6 @@
 //  Mocks.swift
 //
 
-
 import SwiftUI
 import Playbook
 

--- a/Sources/Playbook/Components/Popover/PopoverHandler.swift
+++ b/Sources/Playbook/Components/Popover/PopoverHandler.swift
@@ -10,69 +10,69 @@
 import SwiftUI
 
 struct PopoverView: View {
-    let id: Int
-    let blockBackgroundInteractions: Bool
-    @State private var opacity: CGFloat = 0.01
-    @EnvironmentObject var popoverManager: PopoverManager
-    
-    init(
-        id: Int,
-        blockBackgroundInteractions: Bool
-    ) {
-        self.id = id
-        self.blockBackgroundInteractions = blockBackgroundInteractions
-    }
-    
-    var body: some View {
-        ZStack {
-            let isPresented = popoverManager.isPresented.first { $0.key == id }?.value
-            let popover = popoverManager.popovers.first { $0.key == id }?.value
-           
-            if isPresented ?? false {
-                background
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    popover?.view
-                        .position(popover?.position ?? .zero)
-                        .onTapGesture {
-                            popoverManager.closeInside(id)
-                        }
-                        .onAppear {
-                            if popover?.position != nil {
-                                Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
-                                    opacity = 1
-                                }
-                            } else {
-                                opacity = 0.01
-                            }
-                        }
-                        .opacity(opacity)
-                }
+  let id: Int
+  let blockBackgroundInteractions: Bool
+  @State private var opacity: CGFloat = 0.01
+  @EnvironmentObject var popoverManager: PopoverManager
+
+  init(
+    id: Int,
+    blockBackgroundInteractions: Bool
+  ) {
+    self.id = id
+    self.blockBackgroundInteractions = blockBackgroundInteractions
+  }
+
+  var body: some View {
+    ZStack {
+      let isPresented = popoverManager.isPresented.first { $0.key == id }?.value
+      let popover = popoverManager.popovers.first { $0.key == id }?.value
+
+      if isPresented ?? false {
+        background
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+        popover?.view
+          .position(popover?.position ?? .zero)
+          .onTapGesture {
+            popoverManager.closeInside(id)
+          }
+          .onAppear {
+            if popover?.position != nil {
+              Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
+                opacity = 1
+              }
+            } else {
+              opacity = 0.01
             }
-        }
-    
-    var background: some View {
-        if blockBackgroundInteractions {
-            return  Color.white.opacity(0.01)
-        } else {
-            return Color.clear
-        }
+          }
+          .opacity(opacity)
+      }
     }
+  }
+
+  var background: some View {
+    if blockBackgroundInteractions {
+      return  Color.white.opacity(0.01)
+    } else {
+      return Color.clear
+    }
+  }
 }
 
 public extension View {
-    func popoverHandler(id: Int = 0, blockBackgroundInteractions: Bool = false) -> some View {
-        let popoverManager = PopoverManager.shared
-        return self
-            .overlay(PopoverView(id: id, blockBackgroundInteractions: blockBackgroundInteractions))
-            .onTapGesture { popoverManager.closeOutside() }
-            .environmentObject(popoverManager)
-    }
+  func popoverHandler(id: Int = 0, blockBackgroundInteractions: Bool = false) -> some View {
+    let popoverManager = PopoverManager.shared
+    return self
+      .overlay(PopoverView(id: id, blockBackgroundInteractions: blockBackgroundInteractions))
+      .onTapGesture { popoverManager.closeOutside() }
+      .environmentObject(popoverManager)
+  }
 }
 
 public extension View {
-    public func pbPopoverAppKit<Content: View>(isPresented: Binding<Bool>, position: CGPoint = .init(x: 0, y: 0), @ViewBuilder content: @escaping (() -> Content)) -> some View {
-        self.background(PopHostingView(isPresented: isPresented, position: position, content: content))
-    }
+  func pbPopoverAppKit<Content: View>(isPresented: Binding<Bool>, position: CGPoint = .init(x: 0, y: 0), @ViewBuilder content: @escaping (() -> Content)) -> some View {
+    self.background(PopHostingView(isPresented: isPresented, position: position, content: content))
+  }
 }
 
 
@@ -81,83 +81,83 @@ public extension View {
 import AppKit
 
 struct PopHostingView<Content: View>: NSViewRepresentable {
+  @Binding var isPresented: Bool
+  let position: CGPoint
+  let content: () -> Content
+
+  func makeNSView(context: Context) -> NSView {
+    let nsView = NSView(frame: .zero)
+    return nsView
+  }
+
+  func updateNSView(_ nsView: NSView, context: Context) {
+    if isPresented {
+      context.coordinator.showPopover(from: nsView)
+    } else {
+      context.coordinator.dismissPopover()
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(isPresented: $isPresented, content: content())
+  }
+
+  class Coordinator: NSObject {
+    let popover: NSPopover
     @Binding var isPresented: Bool
-    let position: CGPoint
-    let content: () -> Content
+    let content: Content
 
-    func makeNSView(context: Context) -> NSView {
-        let nsView = NSView(frame: .zero)
-        return nsView
+    init(isPresented: Binding<Bool>, content: Content) {
+      self.popover = NSPopover()
+      self.content = content
+      self._isPresented = isPresented
+      super.init()
+      self.popover.contentViewController = PopViewController(contentView: content)
+      self.popover.behavior = .transient
     }
 
-    func updateNSView(_ nsView: NSView, context: Context) {
-        if isPresented {
-            context.coordinator.showPopover(from: nsView)
-        } else {
-            context.coordinator.dismissPopover()
-        }
+    func showPopover(from sender: NSView) {
+      var positioningView: NSView?
+      positioningView = NSView()
+      positioningView?.frame = sender.frame
+      if let view = positioningView {
+        sender.superview?.addSubview(view, positioned: .below, relativeTo: sender)
+      }
+
+      popover.contentViewController = PopViewController(contentView: content)
+      popover.behavior = .transient
+      popover.show(relativeTo: .zero, of: positioningView!, preferredEdge: .minY)
+
+      positioningView?.frame = NSMakeRect(0, 200, 0, 0)
     }
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(isPresented: $isPresented, content: content())
+    func dismissPopover() {
+      popover.performClose(nil)
+    }
+  }
+
+  class PopViewController: NSViewController {
+    private let contentView: Content
+
+    init(contentView: Content) {
+      self.contentView = contentView
+      super.init(nibName: nil, bundle: nil)
     }
 
-    class Coordinator: NSObject {
-        let popover: NSPopover
-        @Binding var isPresented: Bool
-        let content: Content
-
-        init(isPresented: Binding<Bool>, content: Content) {
-            self.popover = NSPopover()
-            self.content = content
-            self._isPresented = isPresented
-            super.init()
-            self.popover.contentViewController = PopViewController(contentView: content)
-            self.popover.behavior = .transient
-        }
-
-        func showPopover(from sender: NSView) {
-            var positioningView: NSView?
-            positioningView = NSView()
-            positioningView?.frame = sender.frame
-            if let view = positioningView {
-                sender.superview?.addSubview(view, positioned: .below, relativeTo: sender)
-            }
-
-            popover.contentViewController = PopViewController(contentView: content)
-            popover.behavior = .transient
-            popover.show(relativeTo: .zero, of: positioningView!, preferredEdge: .minY)
-
-            positioningView?.frame = NSMakeRect(0, 200, 0, 0)
-        }
-
-        func dismissPopover() {
-            popover.performClose(nil)
-        }
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
     }
 
-    class PopViewController: NSViewController {
-        private let contentView: Content
-
-        init(contentView: Content) {
-                self.contentView = contentView
-                super.init(nibName: nil, bundle: nil)
-            }
-
-            required init?(coder: NSCoder) {
-                fatalError("init(coder:) has not been implemented")
-            }
-
-        override func loadView() {
-            let hostingView = NSHostingView(rootView: contentView)
-            hostingView.layoutSubtreeIfNeeded()
-            let contentSize = hostingView.fittingSize
-            let popoverView = NSView(frame: CGRect(origin: .zero, size: contentSize))
-            hostingView.frame = popoverView.bounds
-            popoverView.addSubview(hostingView)
-            self.view = popoverView
-        }
+    override func loadView() {
+      let hostingView = NSHostingView(rootView: contentView)
+      hostingView.layoutSubtreeIfNeeded()
+      let contentSize = hostingView.fittingSize
+      let popoverView = NSView(frame: CGRect(origin: .zero, size: contentSize))
+      hostingView.frame = popoverView.bounds
+      popoverView.addSubview(hostingView)
+      self.view = popoverView
     }
+  }
 }
 #endif
 
@@ -165,65 +165,65 @@ struct PopHostingView<Content: View>: NSViewRepresentable {
 import UIKit
 
 struct PopHostingView<Content: View>: UIViewRepresentable {
+  @Binding var isPresented: Bool
+  let position: CGPoint
+  let content: () -> Content
+
+  func makeUIView(context: Context) -> UIView {
+    let uiView = UIView(frame: .zero)
+    return uiView
+  }
+
+  func updateUIView(_ uiView: UIView, context: Context) {
+    if isPresented {
+      context.coordinator.showPopover(from: uiView)
+    } else {
+      context.coordinator.dismissPopover()
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(isPresented: $isPresented, position: position, content: content())
+  }
+
+  class Coordinator: NSObject, UIPopoverPresentationControllerDelegate {
+    private let contentViewController: UIHostingController<Content>
+    private weak var anchorView: UIView?
     @Binding var isPresented: Bool
-    let position: CGPoint
-    let content: () -> Content
+    private let position: CGPoint
+    let content: Content
 
-    func makeUIView(context: Context) -> UIView {
-        let uiView = UIView(frame: .zero)
-        return uiView
+    var popoverView: UIView?
+
+    init(isPresented: Binding<Bool>, position: CGPoint, content: Content) {
+      self.contentViewController = UIHostingController(rootView: content)
+      self._isPresented = isPresented
+      self.position = position
+      self.content = content
+      super.init()
+
+      let hostingView = UIHostingController(rootView: content)
+      let popoverView = hostingView.view
+      popoverView?.frame = CGRect(x: position.x, y: position.y, width: 400, height: 400)
+      popoverView?.layer.cornerRadius = 10
+      popoverView?.backgroundColor = .clear
+      self.popoverView = popoverView
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {
-        if isPresented {
-            context.coordinator.showPopover(from: uiView)
-        } else {
-            context.coordinator.dismissPopover()
-        }
+    func showPopover(from anchorView: UIView) {
+      guard let rootVC = anchorView.window?.rootViewController else { return }
+
+      rootVC.modalPresentationStyle = .popover
+      if let popoverView = popoverView {
+        rootVC.view.addSubview(popoverView)
+      }
     }
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(isPresented: $isPresented, position: position, content: content())
+    func dismissPopover() {
+      if let popoverView = popoverView {
+        popoverView.removeFromSuperview()
+      }
     }
-
-    class Coordinator: NSObject, UIPopoverPresentationControllerDelegate {
-        private let contentViewController: UIHostingController<Content>
-        private weak var anchorView: UIView?
-        @Binding var isPresented: Bool
-        private let position: CGPoint
-        let content: Content
-
-        var popoverView: UIView?
-
-        init(isPresented: Binding<Bool>, position: CGPoint, content: Content) {
-            self.contentViewController = UIHostingController(rootView: content)
-            self._isPresented = isPresented
-            self.position = position
-            self.content = content
-            super.init()
-
-            let hostingView = UIHostingController(rootView: content)
-            let popoverView = hostingView.view
-            popoverView?.frame = CGRect(x: position.x, y: position.y, width: 400, height: 400)
-            popoverView?.layer.cornerRadius = 10
-            popoverView?.backgroundColor = .clear
-            self.popoverView = popoverView
-        }
-
-        func showPopover(from anchorView: UIView) {
-            guard let rootVC = anchorView.window?.rootViewController else { return }
-
-            rootVC.modalPresentationStyle = .popover
-            if let popoverView = popoverView {
-                rootVC.view.addSubview(popoverView)
-            }
-        }
-
-        func dismissPopover() {
-            if let popoverView = popoverView {
-                popoverView.removeFromSuperview()
-            }
-        }
-    }
+  }
 }
 #endif

--- a/Sources/Playbook/Components/Typeahead/GridInputField.swift
+++ b/Sources/Playbook/Components/Typeahead/GridInputField.swift
@@ -22,6 +22,7 @@ public struct GridInputField: View {
   @State private var isHovering: Bool = false
   @State private var clearButtonIsHovering: Bool = false
   @State private var indicatorIsHovering: Bool = false
+  @State private var textFrame: CGRect = .zero
 
   init(
     placeholder: String = "Select",
@@ -61,20 +62,20 @@ public struct GridInputField: View {
         }
         .padding(.horizontal, Spacing.small)
         .padding(.vertical, Spacing.xSmall)
-        .background(Color.white.opacity(0.01))
-        .onTapGesture {
-          isFocused.wrappedValue = true
-          if isFocused.wrappedValue {
-            DispatchQueue.main.async {
-              onViewTap?()
-            }
-          }
-        }
+        .frameReader { textFrame = $0 }
         dismissIconView
         indicatorView
       }
       .focused(isFocused)
       .background(backgroundColor)
+      .onTapGesture {
+        isFocused.wrappedValue = true
+        if isFocused.wrappedValue {
+          DispatchQueue.main.async {
+            onViewTap?()
+          }
+        }
+      }
       .overlay {
         shape.stroke(borderColor, lineWidth: 1.0)
       }
@@ -108,25 +109,24 @@ private extension GridInputField {
         .pbFont(.body, color: textColor)
         .frame(height: 24)
     }
-    .fixedSize()
+    .fixedSize(horizontal: true, vertical: false)
     .frame(minWidth: 60, alignment: .leading)
-    .overlay {
-      Color.white
-        .opacity(isFocused.wrappedValue ? 0.001 : 0)
-        .onTapGesture {
-          if isFocused.wrappedValue {
-            onViewTap?()
-          }
-        }
-    }
-    .clipped()
   }
 
   var systemTextField: some View {
     #if os(iOS)
-    KeyboardTextField(text: $searchText, onDelete: { onDelete?() })
+    KeyboardTextField(text: $searchText, maxWidth: maxWidth, onDelete: { onDelete?() })
     #elseif os(macOS)
-    TextField("", text: $searchText)
+    TextField("", text: $searchText).frame(maxWidth: maxWidth)
+    #endif
+  }
+
+  @MainActor
+  var maxWidth: CGFloat {
+    #if os(iOS)
+    return 250
+    #elseif os(macOS)
+    return textFrame.width
     #endif
   }
 

--- a/Sources/Playbook/Components/Typeahead/GridInputField.swift
+++ b/Sources/Playbook/Components/Typeahead/GridInputField.swift
@@ -10,268 +10,279 @@
 import SwiftUI
 
 public struct GridInputField: View {
-    private let placeholder: String
-    private let selection: Selection
-    private let clearAction: (() -> Void)?
-    private let onItemTap: ((Int) -> Void)?
-    private let onViewTap: (() -> Void)?
-    private let shape = RoundedRectangle(cornerRadius: BorderRadius.medium)
-    private var isFocused: FocusState<Bool>.Binding
-    @Binding var searchText: String
-    @State private var isHovering: Bool = false
-    @State private var clearButtonIsHovering: Bool = false
-    @State private var indicatorIsHovering: Bool = false
+  private let placeholder: String
+  private let selection: Selection
+  private let clearAction: (() -> Void)?
+  private let onItemTap: ((Int) -> Void)?
+  private let onViewTap: (() -> Void)?
+  private let onDelete: (() -> Void)?
+  private let shape = RoundedRectangle(cornerRadius: BorderRadius.medium)
+  private var isFocused: FocusState<Bool>.Binding
+  @Binding var searchText: String
+  @State private var isHovering: Bool = false
+  @State private var clearButtonIsHovering: Bool = false
+  @State private var indicatorIsHovering: Bool = false
 
-    init(
-        placeholder: String = "Select",
-        searchText: Binding<String>,
-        selection: Selection,
-        isFocused: FocusState<Bool>.Binding,
-        clearAction: (() -> Void)? = nil,
-        onItemTap: ((Int) -> Void)? = nil,
-        onViewTap: (() -> Void)? = nil
-    ) {
-        self.placeholder = placeholder
-        self._searchText = searchText
-        self.selection = selection
-        self.isFocused = isFocused
-        self.clearAction = clearAction
-        self.onItemTap = onItemTap
-        self.onViewTap = onViewTap
-    }
+  init(
+    placeholder: String = "Select",
+    searchText: Binding<String>,
+    selection: Selection,
+    isFocused: FocusState<Bool>.Binding,
+    clearAction: (() -> Void)? = nil,
+    onItemTap: ((Int) -> Void)? = nil,
+    onViewTap: (() -> Void)? = nil,
+    onDelete: (() -> Void)? = nil
+  ) {
+    self.placeholder = placeholder
+    self._searchText = searchText
+    self.selection = selection
+    self.isFocused = isFocused
+    self.clearAction = clearAction
+    self.onItemTap = onItemTap
+    self.onViewTap = onViewTap
+    self.onDelete = onDelete
+  }
 
-    public var body: some View {
-        VStack(alignment: .leading) {
-            HStack {
-                PBGrid(
-                    alignment: .leading,
-                    horizontalSpacing: Spacing.xSmall,
-                    verticalSpacing: Spacing.xSmall,
-                    fitContent: false
-                ) {
-                    ForEach(indices, id: \.self) { index in
-                        if indices.last != index {
-                            gridView(index: index)
-                        }
-                    }
-                    textfieldWithCustomPlaceholder
-                }
-                .padding(.horizontal, Spacing.small)
-                .padding(.vertical, Spacing.xSmall)
-                .background(Color.white.opacity(0.01))
-                .onTapGesture {
-                    isFocused.wrappedValue = true
-                    if isFocused.wrappedValue {
-                        DispatchQueue.main.async {
-                            onViewTap?()
-                        }
-                    }
-                }
-                dismissIconView
-                indicatorView
+  public var body: some View {
+    VStack(alignment: .leading) {
+      HStack {
+        PBGrid(
+          alignment: .leading,
+          horizontalSpacing: Spacing.xSmall,
+          verticalSpacing: Spacing.xSmall,
+          fitContent: false
+        ) {
+          ForEach(indices, id: \.self) { index in
+            if indices.last != index {
+              gridView(index: index)
             }
-            .focused(isFocused)
-            .background(backgroundColor)
-            .overlay {
-                shape.stroke(borderColor, lineWidth: 1.0)
-            }
+          }
+          textfieldWithCustomPlaceholder
         }
-        .setCursorPointer { isHovering = $0 }
+        .padding(.horizontal, Spacing.small)
+        .padding(.vertical, Spacing.xSmall)
+        .background(Color.white.opacity(0.01))
+        .onTapGesture {
+          isFocused.wrappedValue = true
+          if isFocused.wrappedValue {
+            DispatchQueue.main.async {
+              onViewTap?()
+            }
+          }
+        }
+        dismissIconView
+        indicatorView
+      }
+      .focused(isFocused)
+      .background(backgroundColor)
+      .overlay {
+        shape.stroke(borderColor, lineWidth: 1.0)
+      }
     }
+    .setCursorPointer { isHovering = $0 }
+  }
 }
 
 private extension GridInputField {
-    var indices: Range<Int> {
-        switch selection {
-            case .multiple(_, let options): return Range(0...(options?.count ?? 0))
-            case .single(_): return Range(0...1)
-        }
+  var indices: Range<Int> {
+    switch selection {
+      case .multiple(_, let options): return Range(0...(options?.count ?? 0))
+      case .single(_): return Range(0...1)
     }
-    
-    @ViewBuilder
-    var textfieldWithCustomPlaceholder: some View {
-        ZStack(alignment: .leading) {
-            if searchText.isEmpty {
-                Text(placeholderText)
-                    .pbFont(.body, color: placeholderTextColor)
-            }
-            TextField("", text: $searchText)
-                .onChange(of: searchText) { 
-                    if searchText.first == " " {
-                        searchText = searchText.replacingOccurrences(of: " ", with: "")
-                    }
-                }
-                .textFieldStyle(.plain)
-                .pbFont(.body, color: textColor)
-                .frame(height: 24)
-        }
-        .fixedSize()
-        .frame(minWidth: 60, alignment: .leading)
-        .overlay {
-            Color.white
-                .opacity(isFocused.wrappedValue ? 0.001 : 0)
-                .onTapGesture {
-                    if isFocused.wrappedValue {
-                        onViewTap?()
-                    }
-                }
-        }
-        .clipped()
-    }
+  }
 
-    func gridView(index: Int?) -> AnyView? {
-        switch selection {
-            case .multiple(let variant, let options):
-                if let index = index, let option = options?[index] {
-                    return AnyView(
-                        variant.view(text: option)
-                            .onTapGesture { onItemTap?(index) }
-                    )
-                } else {
-                    return nil
-                }
-            case .single: return nil
+  @ViewBuilder
+  var textfieldWithCustomPlaceholder: some View {
+    ZStack(alignment: .leading) {
+      if searchText.isEmpty {
+        Text(placeholderText)
+          .pbFont(.body, color: placeholderTextColor)
+      }
+      systemTextField
+        .onChange(of: searchText) {
+          if searchText.first == " " {
+            searchText = searchText.replacingOccurrences(of: " ", with: "")
+          }
         }
+        .textFieldStyle(.plain)
+        .pbFont(.body, color: textColor)
+        .frame(height: 24)
     }
-
-    var placeholderText: String {
-        switch selection {
-            case .multiple(_, let elements): return elements?.isEmpty ?? true ? placeholder : ""
-            case .single(let element): return element ?? placeholder
-        }
-    }
-
-    var placeholderTextColor: Color {
-        switch selection {
-            case .multiple(_, _): return .text(.light)
-            case .single(let element):
-                return element == nil ? .text(.light) : .text(.default)
-        }
-    }
-
-    var textColor: Color {
-        return .text(.default)
-    }
-
-    var borderColor: Color {
-        isFocused.wrappedValue ? .pbPrimary : .border
-    }
-
-    @ViewBuilder
-    var dismissIconView: some View {
-        Group {
-            switch selection {
-                case .multiple(_, let elements):
-                    if !(elements?.isEmpty ?? true) {
-                        dismissIcon
-                    }
-                case .single(let element):
-                    if element != nil {
-                        dismissIcon
-                    }
-            }
-        }
+    .fixedSize()
+    .frame(minWidth: 60, alignment: .leading)
+    .overlay {
+      Color.white
+        .opacity(isFocused.wrappedValue ? 0.001 : 0)
         .onTapGesture {
-            clearAction?()
+          if isFocused.wrappedValue {
+            onViewTap?()
+          }
         }
     }
+    .clipped()
+  }
 
-    var dismissIcon: some View {
-        PBIcon(FontAwesome.times, size: .xSmall)
-            .foregroundStyle(iconColor(on: clearButtonIsHovering))
-            .padding(.vertical, Spacing.small)
-            .padding(.leading, Spacing.small)
-            .onHover(disabled: false) {
-                clearButtonIsHovering = $0
-                isHovering = $0
-            }
-    }
+  var systemTextField: some View {
+    #if os(iOS)
+    KeyboardTextField(text: $searchText, onDelete: { onDelete?() })
+    #elseif os(macOS)
+    TextField("", text: $searchText)
+    #endif
+  }
 
-    var backgroundColor: Color {
-        (isHovering || isFocused.wrappedValue) ? .background(.light) : .card
-    }
-
-    var indicatorView: some View {
-        PBIcon(FontAwesome.chevronDown, size: .xSmall)
-            .padding(Spacing.small)
-            .foregroundStyle(iconColor(on: indicatorIsHovering))
-            .onHover(disabled: false) {
-                indicatorIsHovering = $0
-                isHovering = $0
-            }
-            .onTapGesture {
-                isFocused.wrappedValue = true
-                onViewTap?()
-            }
-    }
-
-    func iconColor(on hover: Bool) -> Color {
-        if isFocused.wrappedValue, !hover {
-            return Color.text(.light)
-        } else if !isFocused.wrappedValue, hover {
-            return Color.text(.light)
-        } else if isFocused.wrappedValue, hover {
-            return Color.text(.default)
+  func gridView(index: Int?) -> AnyView? {
+    switch selection {
+      case .multiple(let variant, let options):
+        if let index = index, let option = options?[index] {
+          return AnyView(
+            variant.view(text: option)
+              .onTapGesture { onItemTap?(index) }
+          )
         } else {
-            return Color.text(.lighter)
+          return nil
         }
+      case .single: return nil
     }
+  }
+
+  var placeholderText: String {
+    switch selection {
+      case .multiple(_, let elements): return elements?.isEmpty ?? true ? placeholder : ""
+      case .single(let element): return element ?? placeholder
+    }
+  }
+
+  var placeholderTextColor: Color {
+    switch selection {
+      case .multiple(_, _): return .text(.light)
+      case .single(let element):
+        return element == nil ? .text(.light) : .text(.default)
+    }
+  }
+
+  var textColor: Color {
+    return .text(.default)
+  }
+
+  var borderColor: Color {
+    isFocused.wrappedValue ? .pbPrimary : .border
+  }
+
+  @ViewBuilder
+  var dismissIconView: some View {
+    Group {
+      switch selection {
+        case .multiple(_, let elements):
+          if !(elements?.isEmpty ?? true) {
+            dismissIcon
+          }
+        case .single(let element):
+          if element != nil {
+            dismissIcon
+          }
+      }
+    }
+    .onTapGesture {
+      clearAction?()
+    }
+  }
+
+  var dismissIcon: some View {
+    PBIcon(FontAwesome.times, size: .xSmall)
+      .foregroundStyle(iconColor(on: clearButtonIsHovering))
+      .padding(.vertical, Spacing.small)
+      .padding(.leading, Spacing.small)
+      .onHover(disabled: false) {
+        clearButtonIsHovering = $0
+        isHovering = $0
+      }
+  }
+
+  var backgroundColor: Color {
+    (isHovering || isFocused.wrappedValue) ? .background(.light) : .card
+  }
+
+  var indicatorView: some View {
+    PBIcon(FontAwesome.chevronDown, size: .xSmall)
+      .padding(Spacing.small)
+      .foregroundStyle(iconColor(on: indicatorIsHovering))
+      .onHover(disabled: false) {
+        indicatorIsHovering = $0
+        isHovering = $0
+      }
+      .onTapGesture {
+        isFocused.wrappedValue = true
+        onViewTap?()
+      }
+  }
+
+  func iconColor(on hover: Bool) -> Color {
+    if isFocused.wrappedValue, !hover {
+      return Color.text(.light)
+    } else if !isFocused.wrappedValue, hover {
+      return Color.text(.light)
+    } else if isFocused.wrappedValue, hover {
+      return Color.text(.default)
+    } else {
+      return Color.text(.lighter)
+    }
+  }
 }
 
 public extension GridInputField {
-    enum Selection {
-        case single(String?), multiple(Selection.Variant, [String]?)
+  enum Selection {
+    case single(String?), multiple(Selection.Variant, [String]?)
 
-        public enum Variant {
-            case text, pill, other(AnyView)
+    public enum Variant {
+      case text, pill, other(AnyView)
 
-            @ViewBuilder
-            func view(text: String) -> some View {
-                switch self {
-                    case .text: Text(text).pbFont(.body)
-                    case .pill: TypeaheadPill(text)
-                    case .other(let view): view
-                }
-            }
+      @ViewBuilder
+      func view(text: String) -> some View {
+        switch self {
+          case .text: Text(text).pbFont(.body)
+          case .pill: TypeaheadPill(text)
+          case .other(let view): view
         }
+      }
     }
+  }
 }
 
 #Preview {
-    registerFonts()
-    return WrappedInputFieldCatalog()
+  registerFonts()
+  return WrappedInputFieldCatalog()
 }
 
 public struct WrappedInputFieldCatalog: View {
-    @FocusState private var isFocused
-    @State private var text: String = ""
-    
-    public var body: some View {
-        VStack(spacing: Spacing.medium) {
-            GridInputField(
-                searchText: $text,
-                selection: .single(nil),
-                isFocused: $isFocused
-            )
+  @FocusState private var isFocused
+  @State private var text: String = ""
 
-            GridInputField(
-                searchText: $text,
-                selection: .multiple(.pill, ["title1", "title2", "title2"]),
-                isFocused: $isFocused
-            )
+  public var body: some View {
+    VStack(spacing: Spacing.medium) {
+      GridInputField(
+        searchText: $text,
+        selection: .single(nil),
+        isFocused: $isFocused
+      )
 
-            GridInputField(
-                searchText: $text,
-                selection: .multiple(.other(AnyView(PBPill("oi", variant: .primary))), ["title1", "title2", "title2"]),
-                isFocused: $isFocused
-            )
+      GridInputField(
+        searchText: $text,
+        selection: .multiple(.pill, ["title1", "title2", "title2"]),
+        isFocused: $isFocused
+      )
 
-            GridInputField(
-                searchText: $text,
-                selection: .multiple(.other(AnyView(PBBadge(text: "title", variant: .primary))), ["title1", "title2"]),
-                isFocused: $isFocused
-            )
-        }
-        .padding()
+      GridInputField(
+        searchText: $text,
+        selection: .multiple(.other(AnyView(PBPill("oi", variant: .primary))), ["title1", "title2", "title2"]),
+        isFocused: $isFocused
+      )
+
+      GridInputField(
+        searchText: $text,
+        selection: .multiple(.other(AnyView(PBBadge(text: "title", variant: .primary))), ["title1", "title2"]),
+        isFocused: $isFocused
+      )
     }
+    .padding()
+  }
 }

--- a/Sources/Playbook/Components/Typeahead/KeyboardHandling/KeyboardTextField.swift
+++ b/Sources/Playbook/Components/Typeahead/KeyboardHandling/KeyboardTextField.swift
@@ -1,0 +1,55 @@
+//
+//  Playbook Swift Design System
+//
+//  Copyright © 2025 Power Home Remodeling Group
+//  This software is distributed under the ISC License
+//
+//  UITextField.swift
+//
+
+#if os(iOS)
+import UIKit
+import SwiftUI
+
+class CustomTextField: UITextField {
+  var onDelete: (() -> Void)?
+
+  override func deleteBackward() {
+    onDelete?()
+    super.deleteBackward()
+  }
+}
+
+struct KeyboardTextField: UIViewRepresentable {
+  @Binding var text: String
+  var onDelete: () -> Void
+
+  func makeUIView(context: Context) -> CustomTextField {
+    let textField = CustomTextField(frame: .zero)
+    textField.delegate = context.coordinator
+    textField.onDelete = onDelete
+    textField.borderStyle = .none
+    return textField
+  }
+
+  func updateUIView(_ uiView: CustomTextField, context: Context) {
+    uiView.text = text
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(self)
+  }
+
+  class Coordinator: NSObject, UITextFieldDelegate {
+    var parent: KeyboardTextField
+
+    init(_ parent: KeyboardTextField, placeholder: String = "") {
+      self.parent = parent
+    }
+
+    func textFieldDidChangeSelection(_ textField: UITextField) {
+      parent.text = textField.text ?? ""
+    }
+  }
+}
+#endif

--- a/Sources/Playbook/Components/Typeahead/KeyboardHandling/KeyboardTextField.swift
+++ b/Sources/Playbook/Components/Typeahead/KeyboardHandling/KeyboardTextField.swift
@@ -12,23 +12,33 @@ import UIKit
 import SwiftUI
 
 class CustomTextField: UITextField {
+  var maxWidth: CGFloat?
   var onDelete: (() -> Void)?
 
   override func deleteBackward() {
     onDelete?()
     super.deleteBackward()
   }
+
+  override var intrinsicContentSize: CGSize {
+    let original = super.intrinsicContentSize
+    let cappedWidth = min(original.width, maxWidth ?? original.width)
+    return CGSize(width: cappedWidth, height: original.height)
+  }
 }
 
 struct KeyboardTextField: UIViewRepresentable {
   @Binding var text: String
+  var maxWidth: CGFloat
   var onDelete: () -> Void
 
   func makeUIView(context: Context) -> CustomTextField {
     let textField = CustomTextField(frame: .zero)
     textField.delegate = context.coordinator
     textField.onDelete = onDelete
+    textField.maxWidth = maxWidth
     textField.borderStyle = .none
+    textField.font = .init(name: PBFont.proximaNovaLight, size: PBFont.body.size)
     return textField
   }
 
@@ -48,7 +58,9 @@ struct KeyboardTextField: UIViewRepresentable {
     }
 
     func textFieldDidChangeSelection(_ textField: UITextField) {
-      parent.text = textField.text ?? ""
+      DispatchQueue.main.async { [weak self] in
+        self?.parent.text = textField.text ?? ""
+      }
     }
   }
 }

--- a/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
@@ -11,121 +11,124 @@ import SwiftUI
 
 @MainActor
 public extension PBTypeahead {
-    var titleView: some View {
-        Text(title).pbFont(.caption)
-            .padding(.bottom, Spacing.xxSmall)
-    }
+  var titleView: some View {
+    Text(title).pbFont(.caption)
+      .padding(.bottom, Spacing.xxSmall)
+  }
 
-    var inputField: some View {
-        GridInputField(
-            placeholder: placeholder,
-            searchText: $searchText,
-            selection: selectedInputOptions,
-            isFocused: $isFocused,
-            clearAction: { viewModel.clear() },
-            onItemTap: { viewModel.removeSelected($0) },
-            onViewTap: {
-                isFocused = true
-                viewModel.showPopover.toggle()
+  var inputField: some View {
+    GridInputField(
+      placeholder: placeholder,
+      searchText: $searchText,
+      selection: selectedInputOptions,
+      isFocused: $isFocused,
+      clearAction: { viewModel.clear() },
+      onItemTap: { viewModel.removeSelected($0) },
+      onViewTap: {
+        isFocused = true
+        viewModel.showPopover.toggle()
+      },
+      onDelete: {
+        viewModel.onDeleteKeyPressed()
+      }
+    )
+    .pbPopover(
+      isPresented: $viewModel.showPopover,
+      id: id,
+      position: .bottom(listOffset.x, listOffset.y),
+      variant: .dropdown,
+      refreshView: $viewModel.isHovering
+    ) {
+      listView
+    }
+  }
+
+  var listView: some View {
+    PBCard(alignment: .leading, padding: Spacing.none, shadow: .deeper) {
+      ScrollViewReader { proxy in
+        ScrollView {
+          VStack(spacing: 0) {
+            ForEach(viewModel.searchResults) { result in
+              listItemView(option: result.option, index: result.index)
+                .id(result.id)
             }
-        )
-        .pbPopover(
-            isPresented: $viewModel.showPopover,
-            id: id,
-            position: .bottom(listOffset.x, listOffset.y),
-            variant: .dropdown,
-            refreshView: $viewModel.isHovering
-        ) {
-            listView
+          }
         }
+        .onAppear {
+          viewModel.hoveringIndex = 0
+          isFocused = true
+        }
+        .onChange(of: viewModel.hoveringIndex) { _, newValue in
+          guard let newValue, viewModel.searchResults.indices.contains(newValue) else { return }
+          let id = viewModel.searchResults[newValue].id
+          proxy.scrollTo(id)
+        }
+        .scrollDismissesKeyboard(.immediately)
+        .frame(maxHeight: dropdownMaxHeight)
+        .fixedSize(horizontal: false, vertical: true)
+      }
     }
+  }
 
-    var listView: some View {
-        PBCard(alignment: .leading, padding: Spacing.none, shadow: .deeper) {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    VStack(spacing: 0) {
-                        ForEach(viewModel.searchResults) { result in
-                            listItemView(option: result.option, index: result.index)
-                              .id(result.id)
-                        }
-                    }
-                }
-                .onAppear {
-                    viewModel.hoveringIndex = 0
-                    isFocused = true
-                }
-                .onChange(of: viewModel.hoveringIndex) { _, newValue in
-                    guard let newValue, viewModel.searchResults.indices.contains(newValue) else { return }
-                    let id = viewModel.searchResults[newValue].id
-                    proxy.scrollTo(id)
-                }
-                .scrollDismissesKeyboard(.immediately)
-                .frame(maxHeight: dropdownMaxHeight)
-                .fixedSize(horizontal: false, vertical: true)
-            }
+  func listItemView(option: PBTypeahead.Option, index: Int) -> some View {
+    HStack {
+      if option.text == viewModel.noOptionsText {
+        emptyView
+      } else {
+        Group {
+          if let customView = option.customView?() {
+            customView
+          } else {
+            Text(option.text ?? option.id)
+              .pbFont(.body, color: listTextolor(index))
+          }
         }
-    }
-
-    func listItemView(option: PBTypeahead.Option, index: Int) -> some View {
-        HStack {
-            if option.text == viewModel.noOptionsText {
-                emptyView
-            } else {
-                Group {
-                    if let customView = option.customView?() {
-                        customView
-                    } else {
-                        Text(option.text ?? option.id)
-                            .pbFont(.body, color: listTextolor(index))
-                    }
-                }
-                .padding(.vertical, Spacing.xSmall)
-                .padding(.horizontal, Spacing.xSmall + 4)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(listBackgroundColor(index))
-                .onHover(disabled: false) { hover in
-                    viewModel.isHovering = hover
-                    viewModel.hoveringIndex = index
-                }
-                .onTapGesture {
-                    viewModel.onListSelection(index: index, option: option)
-                }
-            }
-        }
-    }
-
-    var emptyView: some View {
-        HStack {
-            Spacer()
-            Text(viewModel.noOptionsText)
-                .pbFont(.body, color: .text(.light))
-            Spacer()
-        }
+        .padding(.vertical, Spacing.xSmall)
         .padding(.horizontal, Spacing.xSmall + 4)
-        .padding(.vertical, Spacing.xSmall + 4)
-    }
-
-    func listBackgroundColor(_ index: Int?) -> Color {
-        switch viewModel.selection {
-            case .single:
-                if viewModel.selectedIndex != nil, viewModel.selectedIndex == index {
-                    return .pbPrimary
-                }
-            default: break
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(listBackgroundColor(index))
+        .onHover(disabled: false) { hover in
+          viewModel.isHovering = hover
+          viewModel.hoveringIndex = index
         }
-#if os(macOS)
-        return viewModel.hoveringIndex == index ? .hover : .card
-#elseif os(iOS)
-        return .card
-#endif
+        .onTapGesture {
+          viewModel.onListSelection(index: index, option: option)
+        }
+      }
     }
+  }
 
-    func listTextolor(_ index: Int?) -> Color {
+  var emptyView: some View {
+    HStack {
+      Spacer()
+      Text(viewModel.noOptionsText)
+        .pbFont(.body, color: .text(.light))
+      Spacer()
+    }
+    .padding(.horizontal, Spacing.xSmall + 4)
+    .padding(.vertical, Spacing.xSmall + 4)
+  }
+
+  func listBackgroundColor(_ index: Int?) -> Color {
+    switch viewModel.selection {
+      case .single:
         if viewModel.selectedIndex != nil, viewModel.selectedIndex == index {
-            return .white
-        } else {
-            return .text(.default)
+          return .pbPrimary
         }
+      default: break
     }
-} 
+    #if os(macOS)
+    return viewModel.hoveringIndex == index ? .hover : .card
+    #elseif os(iOS)
+    return .card
+    #endif
+  }
+
+  func listTextolor(_ index: Int?) -> Color {
+    if viewModel.selectedIndex != nil, viewModel.selectedIndex == index {
+      return .white
+    } else {
+      return .text(.default)
+    }
+  }
+}

--- a/Sources/Playbook/Components/Typeahead/PBTypeaheadViewModel.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeaheadViewModel.swift
@@ -12,365 +12,369 @@ import Combine
 
 @MainActor
 final class PBTypeaheadViewModel: ObservableObject {
-    @Published var showPopover: Bool = false
-    @Published var hoveringIndex: Int?
-    @Published var isHovering: Bool = false
-    @Published var selectedIndex: Int?
-    @Published var searchResults: [PBTypeahead.DisplayableOption] = []
+  @Published var showPopover: Bool = false
+  @Published var hoveringIndex: Int?
+  @Published var isHovering: Bool = false
+  @Published var selectedIndex: Int?
+  @Published var searchResults: [PBTypeahead.DisplayableOption] = []
 
-    // Configuration (static)
-    private(set) var selection: PBTypeahead.Selection
-    private(set) var debounce: (time: TimeInterval, numberOfCharacters: Int)
-    private var placeholder: String
-    private var disableFiltering: Bool
-    
-    // Constants
-    private(set) var noOptionsText = "No options"
-    
-    // State Publishers
-    var optionsSubject: CurrentValueSubject<[PBTypeahead.Option], Never>!
-    private let searchTermSubject = PassthroughSubject<String, Never>()
-    private var cancellables = Set<AnyCancellable>()
-    
-    // Dependencies (bindings)
-    private var selectedOptionsBinding: Binding<[PBTypeahead.Option]>?
-    private var deselectedOptionsBinding: Binding<[PBTypeahead.Option]>?
-    private var searchTextBinding: Binding<String>?
-    var isFocused: Bool = false
-    private var clearAction: (() -> Void)?
+  // Configuration (static)
+  private(set) var selection: PBTypeahead.Selection
+  private(set) var debounce: (time: TimeInterval, numberOfCharacters: Int)
+  private var placeholder: String
+  private var disableFiltering: Bool
 
-    public init() {
-        self.selection = .single
-        self.debounce = (0, 0)
-        self.placeholder = "Select"
-        self.disableFiltering = false
+  // Constants
+  private(set) var noOptionsText = "No options"
+
+  // State Publishers
+  var optionsSubject: CurrentValueSubject<[PBTypeahead.Option], Never>!
+  private let searchTermSubject = PassthroughSubject<String, Never>()
+  private var cancellables = Set<AnyCancellable>()
+
+  // Dependencies (bindings)
+  private var selectedOptionsBinding: Binding<[PBTypeahead.Option]>?
+  private var deselectedOptionsBinding: Binding<[PBTypeahead.Option]>?
+  private var searchTextBinding: Binding<String>?
+  var isFocused: Bool = false
+  private var clearAction: (() -> Void)?
+
+  public init() {
+    self.selection = .single
+    self.debounce = (0, 0)
+    self.placeholder = "Select"
+    self.disableFiltering = false
+  }
+
+  func configure(
+    selection: PBTypeahead.Selection,
+    options: [PBTypeahead.Option],
+    debounce: (time: TimeInterval, numberOfCharacters: Int),
+    placeholder: String,
+    selectedOptionsBinding: Binding<[PBTypeahead.Option]>,
+    deselectedOptionsBinding: Binding<[PBTypeahead.Option]>,
+    searchTextBinding: Binding<String>,
+    isFocused: Bool,
+    clearAction: (() -> Void)?,
+    disableFiltering: Bool
+  ) {
+    self.selection = selection
+    self.debounce = debounce
+    self.placeholder = placeholder
+    self.disableFiltering = disableFiltering
+    self.selectedOptionsBinding = selectedOptionsBinding
+    self.deselectedOptionsBinding = deselectedOptionsBinding
+    self.searchTextBinding = searchTextBinding
+    self.isFocused = isFocused
+    self.clearAction = clearAction
+
+    self.optionsSubject = CurrentValueSubject(options)
+
+    let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
+    let filteredOptions = options.filter { option in
+      !selectedIds.contains(option.id)
     }
-    
-    func configure(
-        selection: PBTypeahead.Selection,
-        options: [PBTypeahead.Option],
-        debounce: (time: TimeInterval, numberOfCharacters: Int),
-        placeholder: String,
-        selectedOptionsBinding: Binding<[PBTypeahead.Option]>,
-        deselectedOptionsBinding: Binding<[PBTypeahead.Option]>,
-        searchTextBinding: Binding<String>,
-        isFocused: Bool,
-        clearAction: (() -> Void)?,
-        disableFiltering: Bool
-    ) {
-        self.selection = selection
-        self.debounce = debounce
-        self.placeholder = placeholder
-        self.disableFiltering = disableFiltering
-        self.selectedOptionsBinding = selectedOptionsBinding
-        self.deselectedOptionsBinding = deselectedOptionsBinding
-        self.searchTextBinding = searchTextBinding
-        self.isFocused = isFocused
-        self.clearAction = clearAction
-        
-        self.optionsSubject = CurrentValueSubject(options)
+    self.searchResults = PBTypeaheadViewModel.optionToDisplayable(filteredOptions)
 
+    if disableFiltering {
+      observeOptions()
+    } else {
+      observeSearchTextAndSearchResults()
+    }
+
+    if isFocused {
+      showPopover = true
+    }
+
+    reloadList()
+  }
+
+  private static func optionToDisplayable(_ options: [PBTypeahead.Option]) -> [PBTypeahead.DisplayableOption] {
+    options.enumerated().map { index, option in
+        .init(option: option, index: index)
+    }
+  }
+
+  private func observeOptions() {
+    optionsSubject
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] options in
+        guard let self = self else { return }
         let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
-        let filteredOptions = options.filter { option in
-            !selectedIds.contains(option.id)
+        let results = options.filter { option in
+          !selectedIds.contains(option.id)
         }
-        self.searchResults = PBTypeaheadViewModel.optionToDisplayable(filteredOptions)
+        self.searchResults = PBTypeaheadViewModel.optionToDisplayable(results)
 
-        if disableFiltering {
-            observeOptions()
-        } else {
-            observeSearchTextAndSearchResults()
+        self.reloadList()
+        if !(self.searchTextBinding?.wrappedValue.isEmpty ?? true) {
+          self.showPopover = true
         }
-        
-        if isFocused {
-            showPopover = true
-        }
-        
-        reloadList()
+      }
+      .store(in: &cancellables)
+  }
+
+  private func observeSearchTextAndSearchResults() {
+    var searchTerm = searchTermSubject.debounce(for: .seconds(debounce.time), scheduler: DispatchQueue.global()).eraseToAnyPublisher()
+
+    if debounce.time == 0 {
+      searchTerm = searchTermSubject.eraseToAnyPublisher()
     }
 
-    private static func optionToDisplayable(_ options: [PBTypeahead.Option]) -> [PBTypeahead.DisplayableOption] {
-        options.enumerated().map { index, option in
-            .init(option: option, index: index)
-        }
-    }
-
-    private func observeOptions() {
-        optionsSubject
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] options in
-                guard let self = self else { return }
-                let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
-                let results = options.filter { option in
-                    !selectedIds.contains(option.id)
-                }
-                self.searchResults = PBTypeaheadViewModel.optionToDisplayable(results)
-              
-                self.reloadList()
-                if !(self.searchTextBinding?.wrappedValue.isEmpty ?? true) {
-                    self.showPopover = true
-                }
-            }
-            .store(in: &cancellables)
-    }
-
-    private func observeSearchTextAndSearchResults() {
-        var searchTerm = searchTermSubject.debounce(for: .seconds(debounce.time), scheduler: DispatchQueue.global()).eraseToAnyPublisher()
-
-        if debounce.time == 0 {
-            searchTerm = searchTermSubject.eraseToAnyPublisher()
-        }
-
-        searchTerm
-            .receive(on: DispatchQueue.main)
-            .map { [weak self] text -> (String, [PBTypeahead.Option], Set<String>) in
-                guard let self = self else { return (text, [], []) }
-                let currentOptions = self.optionsSubject.value
-                let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
-                return (text, currentOptions, selectedIds)
-            }
-            .receive(on: DispatchQueue.global())
-            .map { [weak self] (text, options, selectedIds) -> [PBTypeahead.Option] in
-                guard let self = self else { return [] }
-                return self.getSearchResults(text, options: options, selectedIds: selectedIds)
-            }
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] results in
-                guard let self else { return }
-                self.searchResults = PBTypeaheadViewModel.optionToDisplayable(results)
-                self.hoveringIndex = 0
-                self.reloadList()
-
-                if !(self.searchTextBinding?.wrappedValue.isEmpty ?? true) {
-                    self.showPopover = true
-                }
-            }
-            .store(in: &cancellables)
-    }
-    
-    private func updateSearchText(_ newText: String) {
-        searchTextBinding?.wrappedValue = newText
-    }
-    
-    private func updateSelectedOptions(_ newOptions: [PBTypeahead.Option]) {
-        selectedOptionsBinding?.wrappedValue = newOptions
-    }
-    
-    func onListSelection(index: Int, option: PBTypeahead.Option) {
-        guard option.text != noOptionsText else { return }
-        
-        switch selection {
-        case .single:
-            onSingleSelection(index: index, option: option)
-        case .multiple:
-            onMultipleSelection(option: option)
-        }
-
+    searchTerm
+      .receive(on: DispatchQueue.main)
+      .map { [weak self] text -> (String, [PBTypeahead.Option], Set<String>) in
+        guard let self = self else { return (text, [], []) }
+        let currentOptions = self.optionsSubject.value
         let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
-        let filteredOptions = self.optionsSubject.value.filter {
-            !selectedIds.contains($0.id)
-        }
-        self.searchResults = PBTypeaheadViewModel.optionToDisplayable(filteredOptions)
+        return (text, currentOptions, selectedIds)
+      }
+      .receive(on: DispatchQueue.global())
+      .map { [weak self] (text, options, selectedIds) -> [PBTypeahead.Option] in
+        guard let self = self else { return [] }
+        return self.getSearchResults(text, options: options, selectedIds: selectedIds)
+      }
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] results in
+        guard let self else { return }
+        self.searchResults = PBTypeaheadViewModel.optionToDisplayable(results)
+        self.hoveringIndex = 0
+        self.reloadList()
 
-        showPopover = false
-        updateSearchText("")
-        reloadList()
-    }
-    
-    private func onSingleSelection(index: Int, option: PBTypeahead.Option) {
-        removeFromDeselectedOptions(option)
-        
-        if let currentSelected = selectedOptionsBinding?.wrappedValue.first {
-            addToDeselectedOptions(currentSelected)
+        if !(self.searchTextBinding?.wrappedValue.isEmpty ?? true) {
+          self.showPopover = true
         }
-        
-        updateSelectedOptions([option])
-        selectedIndex = index
-        hoveringIndex = index
-        reloadList()
-    }
-    
-    private func onMultipleSelection(option: PBTypeahead.Option) {
-        removeFromDeselectedOptions(option)
-        
-        addToSelectedOptions(option)
-        hoveringIndex = nil
-        selectedIndex = nil
-        reloadList()
-    }
-    
-    func removeSelected(_ index: Int) {
-        guard var currentOptions = selectedOptionsBinding?.wrappedValue,
-              let selectedElementIndex = currentOptions.indices.first(where: { $0 == index }) else { return }
-        
-        let deselectedOption = currentOptions[selectedElementIndex]
-        currentOptions.remove(at: selectedElementIndex)
-        updateSelectedOptions(currentOptions)
-        
-        addToDeselectedOptions(deselectedOption)
-        
-        selectedIndex = nil
-        hoveringIndex = 0
+      }
+      .store(in: &cancellables)
+  }
 
-        let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
-        let filteredOptions = self.optionsSubject.value.filter {
-            !selectedIds.contains($0.id)
-        }
-        self.searchResults = PBTypeaheadViewModel.optionToDisplayable(filteredOptions)
+  private func updateSearchText(_ newText: String) {
+    searchTextBinding?.wrappedValue = newText
+  }
 
-        reloadList()
-    }
-    
-    func clear() {
-        if let action = clearAction {
-            action()
-        }
-        
-        if let currentSelectedOptions = selectedOptionsBinding?.wrappedValue {
-            for option in currentSelectedOptions {
-                addToDeselectedOptions(option)
-            }
-        }
-        
-        updateSearchText("")
-        updateSelectedOptions([])
-        selectedIndex = nil
-        hoveringIndex = nil
-        showPopover = false
-    }
-    
-    func reloadList() {
-        isHovering.toggle()
-    }
-    
-    var optionsSelected: GridInputField.Selection {
-        let options = selectedOptionsBinding?.wrappedValue ?? []
-        let optionsSelected = options.map { value in
-            value.text ?? value.id
-        }
-        return selection.selectedOptions(options: optionsSelected, placeholder: placeholder)
+  private func updateSelectedOptions(_ newOptions: [PBTypeahead.Option]) {
+    selectedOptionsBinding?.wrappedValue = newOptions
+  }
+
+  func onListSelection(index: Int, option: PBTypeahead.Option) {
+    guard option.text != noOptionsText else { return }
+
+    switch selection {
+      case .single:
+        onSingleSelection(index: index, option: option)
+      case .multiple:
+        onMultipleSelection(option: option)
     }
 
-    func optionsChanged(_ newOptions: [PBTypeahead.Option]) {
-        optionsSubject.send(newOptions)
+    let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
+    let filteredOptions = self.optionsSubject.value.filter {
+      !selectedIds.contains($0.id)
+    }
+    self.searchResults = PBTypeaheadViewModel.optionToDisplayable(filteredOptions)
+
+    showPopover = false
+    updateSearchText("")
+    reloadList()
+  }
+
+  private func onSingleSelection(index: Int, option: PBTypeahead.Option) {
+    removeFromDeselectedOptions(option)
+
+    if let currentSelected = selectedOptionsBinding?.wrappedValue.first {
+      addToDeselectedOptions(currentSelected)
     }
 
-    func searchTermChanged(_ newTerm: String) {
-        searchTermSubject.send(newTerm)
+    updateSelectedOptions([option])
+    selectedIndex = index
+    hoveringIndex = index
+    reloadList()
+  }
+
+  private func onMultipleSelection(option: PBTypeahead.Option) {
+    removeFromDeselectedOptions(option)
+
+    addToSelectedOptions(option)
+    hoveringIndex = nil
+    selectedIndex = nil
+    reloadList()
+  }
+
+  func removeSelected(_ index: Int) {
+    guard var currentOptions = selectedOptionsBinding?.wrappedValue,
+          let selectedElementIndex = currentOptions.indices.first(where: { $0 == index }) else { return }
+
+    let deselectedOption = currentOptions[selectedElementIndex]
+    currentOptions.remove(at: selectedElementIndex)
+    updateSelectedOptions(currentOptions)
+
+    addToDeselectedOptions(deselectedOption)
+
+    selectedIndex = nil
+    hoveringIndex = 0
+
+    let selectedIds = Set(self.selectedOptionsBinding?.wrappedValue.map(\.id) ?? [])
+    let filteredOptions = self.optionsSubject.value.filter {
+      !selectedIds.contains($0.id)
     }
-    
-    private func getSearchResults(
-        _ text: String,
-        options: [PBTypeahead.Option],
-        selectedIds: Set<String>
-    ) -> [PBTypeahead.Option] {
-        let shouldShowAllOptions = text.isEmpty && debounce.numberOfCharacters == 0
-        
-        let filteredOptions = shouldShowAllOptions ? options : options.filter { option in
-            if let optionText = option.text {
-                return optionText.localizedCaseInsensitiveContains(text)
-            } else {
-                return option.id.localizedCaseInsensitiveContains(text)
-            }
-        }
-        
-        let filteredSelectedOptions = filteredOptions.filter { option in
-            !selectedIds.contains(option.id)
-        }
-        
-        let emptyStateOption = PBTypeahead.Option(
-            id: "",
-            text: noOptionsText,
-            customView: nil
-        )
-        
-        switch selection {
-        case .multiple:
-            return filteredSelectedOptions.isEmpty
-                ? [emptyStateOption]
-                : filteredSelectedOptions
-                
-        case .single:
-            return filteredSelectedOptions.isEmpty
-                ? [emptyStateOption]
-                : filteredSelectedOptions
-        }
+    self.searchResults = PBTypeaheadViewModel.optionToDisplayable(filteredOptions)
+
+    reloadList()
+  }
+
+  func clear() {
+    if let action = clearAction {
+      action()
     }
 
-    private func addToSelectedOptions(_ option: PBTypeahead.Option) {
-        guard var currentOptions = selectedOptionsBinding?.wrappedValue else { return }
-        guard !currentOptions.contains(where: { $0.id == option.id }) else { return }
-        currentOptions.append(option)
-        updateSelectedOptions(currentOptions)
+    if let currentSelectedOptions = selectedOptionsBinding?.wrappedValue {
+      for option in currentSelectedOptions {
+        addToDeselectedOptions(option)
+      }
     }
 
-    private func addToDeselectedOptions(_ option: PBTypeahead.Option) {
-        guard var deselectedOptions = deselectedOptionsBinding?.wrappedValue else { return }
-        guard !deselectedOptions.contains(where: { $0.id == option.id }) else { return }
-        deselectedOptions.append(option)
-        deselectedOptionsBinding?.wrappedValue = deselectedOptions
+    updateSearchText("")
+    updateSelectedOptions([])
+    selectedIndex = nil
+    hoveringIndex = nil
+    showPopover = false
+  }
+
+  func reloadList() {
+    isHovering.toggle()
+  }
+
+  var optionsSelected: GridInputField.Selection {
+    let options = selectedOptionsBinding?.wrappedValue ?? []
+    let optionsSelected = options.map { value in
+      value.text ?? value.id
+    }
+    return selection.selectedOptions(options: optionsSelected, placeholder: placeholder)
+  }
+
+  func optionsChanged(_ newOptions: [PBTypeahead.Option]) {
+    optionsSubject.send(newOptions)
+  }
+
+  func searchTermChanged(_ newTerm: String) {
+    searchTermSubject.send(newTerm)
+  }
+
+  private func getSearchResults(
+    _ text: String,
+    options: [PBTypeahead.Option],
+    selectedIds: Set<String>
+  ) -> [PBTypeahead.Option] {
+    let shouldShowAllOptions = text.isEmpty && debounce.numberOfCharacters == 0
+
+    let filteredOptions = shouldShowAllOptions ? options : options.filter { option in
+      if let optionText = option.text {
+        return optionText.localizedCaseInsensitiveContains(text)
+      } else {
+        return option.id.localizedCaseInsensitiveContains(text)
+      }
     }
 
-    private func removeFromDeselectedOptions(_ option: PBTypeahead.Option) {
-        guard var deselectedOptions = deselectedOptionsBinding?.wrappedValue else { return }
-        deselectedOptions.removeAll { $0.id == option.id }
-        deselectedOptionsBinding?.wrappedValue = deselectedOptions
+    let filteredSelectedOptions = filteredOptions.filter { option in
+      !selectedIds.contains(option.id)
     }
+
+    let emptyStateOption = PBTypeahead.Option(
+      id: "",
+      text: noOptionsText,
+      customView: nil
+    )
+
+    switch selection {
+      case .multiple:
+        return filteredSelectedOptions.isEmpty
+        ? [emptyStateOption]
+        : filteredSelectedOptions
+
+      case .single:
+        return filteredSelectedOptions.isEmpty
+        ? [emptyStateOption]
+        : filteredSelectedOptions
+    }
+  }
+
+  private func addToSelectedOptions(_ option: PBTypeahead.Option) {
+    guard var currentOptions = selectedOptionsBinding?.wrappedValue else { return }
+    guard !currentOptions.contains(where: { $0.id == option.id }) else { return }
+    currentOptions.append(option)
+    updateSelectedOptions(currentOptions)
+  }
+
+  private func addToDeselectedOptions(_ option: PBTypeahead.Option) {
+    guard var deselectedOptions = deselectedOptionsBinding?.wrappedValue else { return }
+    guard !deselectedOptions.contains(where: { $0.id == option.id }) else { return }
+    deselectedOptions.append(option)
+    deselectedOptionsBinding?.wrappedValue = deselectedOptions
+  }
+
+  private func removeFromDeselectedOptions(_ option: PBTypeahead.Option) {
+    guard var deselectedOptions = deselectedOptionsBinding?.wrappedValue else { return }
+    deselectedOptions.removeAll { $0.id == option.id }
+    deselectedOptionsBinding?.wrappedValue = deselectedOptions
+  }
+
+  func onDeleteKeyPressed() -> Bool {
+    guard isFocused else { return false }
+    // Only delete when search field is empty and there are selected options
+    if searchTextBinding?.wrappedValue.isEmpty == true,
+       let currentOptions = selectedOptionsBinding?.wrappedValue,
+       !currentOptions.isEmpty {
+      removeSelected(currentOptions.count - 1)  // Remove last item
+      return true
+    }
+    return false
+  }
 }
 
 #if os(macOS)
-extension PBTypeaheadViewModel: TypeaheadKeyboardDelegate {
-    func onKeyPress(_ key: KeyCode) -> Bool {
-        switch key {
-        case .tab:
-            isFocused = true
-            return false
-            
-        case .return:
-            guard isFocused else { return false }
-            guard showPopover,
-                  let index = hoveringIndex,
-                  index < searchResults.count else {
-                return false
-            }
-            let option = searchResults[index]
-            onListSelection(index: index, option: option.option)
-            return true
+extension PBTypeaheadViewModel: @preconcurrency TypeaheadKeyboardDelegate {
+  func onKeyPress(_ key: KeyCode) -> Bool {
+    switch key {
+      case .tab:
+        isFocused = true
+        return false
 
-        case .backspace:
-            guard isFocused else { return false }
-            // Only delete when search field is empty and there are selected options
-            if searchTextBinding?.wrappedValue.isEmpty == true,
-               let currentOptions = selectedOptionsBinding?.wrappedValue,
-               !currentOptions.isEmpty {
-                removeSelected(currentOptions.count - 1)  // Remove last item
-                return true
-            }
-            return false
-            
-        case .downArrow:
-            guard isFocused, showPopover else { return false }
-            let currentIndex = hoveringIndex ?? 0
-            let newHoveringIndex = min(currentIndex + 1, searchResults.count - 1)
-            hoveringIndex = newHoveringIndex
-            return true
-
-        case .upArrow:
-            guard isFocused, showPopover else { return false }
-            let currentIndex = hoveringIndex ?? 0
-            let newHoveringIndex = max(currentIndex - 1, 0)
-            hoveringIndex = newHoveringIndex
-            return true
-
-        case .space:
+      case .return:
+        guard isFocused else { return false }
+        guard showPopover,
+              let index = hoveringIndex,
+              index < searchResults.count else {
           return false
-
-        case .escape:
-            guard isFocused, showPopover else { return false }
-            showPopover = false
-            isFocused = false
-            return true
         }
+        let option = searchResults[index]
+        onListSelection(index: index, option: option.option)
+        return true
+
+      case .backspace:
+        return onDeleteKeyPressed()
+
+      case .downArrow:
+        guard isFocused, showPopover else { return false }
+        let currentIndex = hoveringIndex ?? 0
+        let newHoveringIndex = min(currentIndex + 1, searchResults.count - 1)
+        hoveringIndex = newHoveringIndex
+        return true
+
+      case .upArrow:
+        guard isFocused, showPopover else { return false }
+        let currentIndex = hoveringIndex ?? 0
+        let newHoveringIndex = max(currentIndex - 1, 0)
+        hoveringIndex = newHoveringIndex
+        return true
+
+      case .space:
+        return false
+
+      case .escape:
+        guard isFocused, showPopover else { return false }
+        showPopover = false
+        isFocused = false
+        return true
     }
+  }
 }
-#endif 
+#endif


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Added a custom textfield to the iOS target to manage digital keyboard commands. 
Now the user can delete selected items using the keyboard on iOS

**Screenshots:** Screenshots to visualize your addition/change
https://github.com/user-attachments/assets/e44b0a8f-5c3b-4c96-8e5a-69f1bb21e7ba


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change

### Checklist
- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
