### PR TITLE
[PBIOS-680] Fix typeahead cursor

### DIFF
--- a/Sources/Playbook/Components/Typeahead/GridInputField.swift
+++ b/Sources/Playbook/Components/Typeahead/GridInputField.swift
@@ -22,6 +22,7 @@ public struct GridInputField: View {
   @State private var isHovering: Bool = false
   @State private var clearButtonIsHovering: Bool = false
   @State private var indicatorIsHovering: Bool = false
+  @State private var textFrame: CGRect = .zero
 
   init(
     placeholder: String = "Select",
@@ -61,20 +62,20 @@ public struct GridInputField: View {
         }
         .padding(.horizontal, Spacing.small)
         .padding(.vertical, Spacing.xSmall)
-        .background(Color.white.opacity(0.01))
-        .onTapGesture {
-          isFocused.wrappedValue = true
-          if isFocused.wrappedValue {
-            DispatchQueue.main.async {
-              onViewTap?()
-            }
-          }
-        }
+        .frameReader { textFrame = $0 }
         dismissIconView
         indicatorView
       }
       .focused(isFocused)
       .background(backgroundColor)
+      .onTapGesture {
+        isFocused.wrappedValue = true
+        if isFocused.wrappedValue {
+          DispatchQueue.main.async {
+            onViewTap?()
+          }
+        }
+      }
       .overlay {
         shape.stroke(borderColor, lineWidth: 1.0)
       }
@@ -108,25 +109,24 @@ private extension GridInputField {
         .pbFont(.body, color: textColor)
         .frame(height: 24)
     }
-    .fixedSize()
+    .fixedSize(horizontal: true, vertical: false)
     .frame(minWidth: 60, alignment: .leading)
-    .overlay {
-      Color.white
-        .opacity(isFocused.wrappedValue ? 0.001 : 0)
-        .onTapGesture {
-          if isFocused.wrappedValue {
-            onViewTap?()
-          }
-        }
-    }
-    .clipped()
   }
 
   var systemTextField: some View {
     #if os(iOS)
-    KeyboardTextField(text: $searchText, onDelete: { onDelete?() })
+    KeyboardTextField(text: $searchText, maxWidth: maxWidth, onDelete: { onDelete?() })
     #elseif os(macOS)
-    TextField("", text: $searchText)
+    TextField("", text: $searchText).frame(maxWidth: maxWidth)
+    #endif
+  }
+
+  @MainActor
+  var maxWidth: CGFloat {
+    #if os(iOS)
+    return 250
+    #elseif os(macOS)
+    return textFrame.width
     #endif
   }
 

--- a/Sources/Playbook/Components/Typeahead/KeyboardHandling/KeyboardTextField.swift
+++ b/Sources/Playbook/Components/Typeahead/KeyboardHandling/KeyboardTextField.swift
@@ -12,23 +12,33 @@ import UIKit
 import SwiftUI
 
 class CustomTextField: UITextField {
+  var maxWidth: CGFloat?
   var onDelete: (() -> Void)?
 
   override func deleteBackward() {
     onDelete?()
     super.deleteBackward()
   }
+
+  override var intrinsicContentSize: CGSize {
+    let original = super.intrinsicContentSize
+    let cappedWidth = min(original.width, maxWidth ?? original.width)
+    return CGSize(width: cappedWidth, height: original.height)
+  }
 }
 
 struct KeyboardTextField: UIViewRepresentable {
   @Binding var text: String
+  var maxWidth: CGFloat
   var onDelete: () -> Void
 
   func makeUIView(context: Context) -> CustomTextField {
     let textField = CustomTextField(frame: .zero)
     textField.delegate = context.coordinator
     textField.onDelete = onDelete
+    textField.maxWidth = maxWidth
     textField.borderStyle = .none
+    textField.font = .init(name: PBFont.proximaNovaLight, size: PBFont.body.size)
     return textField
   }
 
@@ -48,7 +58,9 @@ struct KeyboardTextField: UIViewRepresentable {
     }
 
     func textFieldDidChangeSelection(_ textField: UITextField) {
-      parent.text = textField.text ?? ""
+      DispatchQueue.main.async { [weak self] in
+        self?.parent.text = textField.text ?? ""
+      }
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.
Fix cursor not appearing immediately when a user clicks into a typeahead field — no need to start typing first.

**Fix applies uniformly across:**
- Individual criteria typeahead fields
- Audience criteria typeahead fields

**Maintains existing functionality:**
- Typing
- Clearing values
- Selecting options from the dropdown
- No regressions observed in input behavior or interactivity

**How It Was Fixed:**
- Updated focus handling logic in the typeahead component to ensure the underlying input element receives immediate focus on click.
- Verified that any wrappers or custom components do not intercept or delay input focus.
- Minor style tweaks (where needed) to prevent focus outlines or cursor visibility from being visually suppressed.

**Steps to Validate:**
- Navigate to any typeahead field (individual or audience criteria).
- Click into the field without typing.
- Confirm that the text cursor is visible immediately.
- Test typing, clearing, and selecting to ensure no functionality was impacted.

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change

### Checklist
- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
