### PR TITLE
[RANGR-1025] Enable Kits to Allow Inactive User

### DIFF
--- a/PlaybookShowcase/PlaybookShowcase/Components/Message/MessageCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/Message/MessageCatalog.swift
@@ -189,7 +189,7 @@ extension MessageCatalog {
 
   var inactiveUserView: some View {
     PBMessage(
-      avatar: AnyView(PBAvatar(image: Image("Anna"), size: .medium, status: .offline, isActive: false)),
+      avatar: AnyView(PBAvatar(image: Image("Anna"), size: .small, status: .offline, isActive: false)),
       label: "Patrick Welch",
       message: "We will escalate this issue to a Senior Support agent.",
       timestamp: Date().addingTimeInterval(-540),

--- a/PlaybookShowcase/PlaybookShowcase/Components/Message/MessageCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/Message/MessageCatalog.swift
@@ -189,7 +189,7 @@ extension MessageCatalog {
 
   var inactiveUserView: some View {
     PBMessage(
-      avatar: AnyView(PBAvatar(image: Image("Anna"), size: .small, status: .offline, isActive: false)),
+      avatar: AnyView(PBAvatar(image: Image("Anna"), size: .xSmall, status: .offline, isActive: false)),
       label: "Patrick Welch",
       message: "We will escalate this issue to a Senior Support agent.",
       timestamp: Date().addingTimeInterval(-540),

--- a/PlaybookShowcase/PlaybookShowcase/Components/Message/MessageCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/Message/MessageCatalog.swift
@@ -31,6 +31,9 @@ public struct MessageCatalog: View {
       PBDoc(title: "On user click") {
         onUserClickView
       }
+      PBDoc(title: "Inactive User") {
+        inactiveUserView
+      }
     }
     .popoverHandler(id: 9)
   }
@@ -182,6 +185,17 @@ extension MessageCatalog {
         Text("This is a popover")
       }
     }
+  }
+
+  var inactiveUserView: some View {
+    PBMessage(
+      avatar: AnyView(PBAvatar(image: Image("Anna"), size: .medium, status: .offline, isActive: false)),
+      label: "Patrick Welch",
+      message: "We will escalate this issue to a Senior Support agent.",
+      timestamp: Date().addingTimeInterval(-540),
+      timestampAlignment: .leading,
+      isActive: false
+    )
   }
 
   private func showDialog() {

--- a/PlaybookShowcase/PlaybookShowcase/Components/User/UserCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/User/UserCatalog.swift
@@ -283,7 +283,7 @@ public extension UserCatalog {
         name: name,
         image: img,
         orientation: .horizontal,
-        size: .large,
+        size: .small,
         territory: "PHL",
         title: title,
         status: .offline,

--- a/PlaybookShowcase/PlaybookShowcase/Components/User/UserCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/User/UserCatalog.swift
@@ -26,6 +26,7 @@ public struct UserCatalog: View {
       PBDoc(title: "Block Content Subtitle") { subtitleBlockContentView }
       PBDoc(title: "Presence Indicator") { presenceIndicatorView }
       PBDoc(title: "Custom Title Font") { customFontsView }
+      PBDoc(title: "Inactive User") { inactiveUserView }
     }
   }
 }
@@ -275,6 +276,19 @@ public extension UserCatalog {
         )
       }
     }
+  }
+
+  var inactiveUserView: some View {
+    PBUser(
+        name: name,
+        image: img,
+        orientation: .horizontal,
+        size: .large,
+        territory: "PHL",
+        title: title,
+        status: .offline,
+        isActive: false
+    )
   }
 }
 

--- a/PlaybookShowcase/PlaybookShowcase/Components/User/UserCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/User/UserCatalog.swift
@@ -287,7 +287,8 @@ public extension UserCatalog {
         territory: "PHL",
         title: title,
         status: .offline,
-        isActive: false
+        isActive: false,
+        hasInactiveBadge: true
     )
   }
 }

--- a/Sources/Playbook/Components/Avatar/PBAvatar.swift
+++ b/Sources/Playbook/Components/Avatar/PBAvatar.swift
@@ -58,7 +58,6 @@ public struct PBAvatar: View {
           .frame(width: size.diameter + 1, height: size.diameter + 1)
       }
 
-      
       if let status = self.status {
         PBOnlineStatus(status: status, size: avatarStatusSize, variant: .border)
           .grayscale(isActive ? 0 : 1)

--- a/Sources/Playbook/Components/Message/PBMessage.swift
+++ b/Sources/Playbook/Components/Message/PBMessage.swift
@@ -24,6 +24,7 @@ public struct PBMessage<Content: View>: View {
   let content: Content?
   let timestampVariant: PBTimestamp.Variant
   var isOnClick: Bool
+  var isActive: Bool
   let onHeaderClick: (() -> Void)?
   @Binding var isLoading: Bool
   @State private var isHovering: Bool = false
@@ -42,6 +43,7 @@ public struct PBMessage<Content: View>: View {
     showMessageDate: Bool = false,
     showMessageUser: Bool = false,
     isOnClick: Bool = false,
+    isActive: Bool = true,
     isLoading: Binding<Bool> = .constant(false),
     onHeaderClick: (() -> Void)? = nil,
     @ViewBuilder content: (() -> Content) = { EmptyView() }
@@ -59,6 +61,7 @@ public struct PBMessage<Content: View>: View {
     self.showMessageDate = showMessageDate
     self.showMessageUser = showMessageUser
     self.isOnClick = isOnClick
+    self.isActive = isActive
     self._isLoading = isLoading
     self.onHeaderClick = onHeaderClick
     self.content = content()
@@ -75,7 +78,7 @@ public struct PBMessage<Content: View>: View {
       VStack(alignment: .leading, spacing: Spacing.none) {
         HStack(spacing: Spacing.xSmall) {
           Text(label)
-            .pbFont(.messageTitle, color: isLoading ? .text(.light) : .text(.default))
+            .pbFont(.messageTitle, color: isLoading || !isActive ? .text(.light) : .text(.default))
             .setCursorPointer(disabled: !isCursorEnabled)
             .onTapGesture { onHeaderClick?() }
           if timestampAlignment == .trailing {

--- a/Sources/Playbook/Components/User/Multiple Users Stacked/PBMultipleUsersStacked.swift
+++ b/Sources/Playbook/Components/User/Multiple Users Stacked/PBMultipleUsersStacked.swift
@@ -12,23 +12,25 @@ import SwiftUI
 public struct PBMultipleUsersStacked: View {
   var users: [PBUser]
   var size: Size
-
+  var isActive: Bool
   public init(
     users: [PBUser] = [],
-    size: Size = .small
+    size: Size = .small,
+    isActive: Bool = true
   ) {
     self.users = users
     self.size = size
+    self.isActive = isActive
   }
 
   public var body: some View {
     if users.count == 1 {
-      PBAvatar(image: users[0].image, name: users[0].name, size: avatarSize)
+      PBAvatar(image: users[0].image, name: users[0].name, size: avatarSize, isActive: isActive)
     } else if users.count >= 2 {
       ZStack {
-        PBAvatar(image: users[0].image, name: users[0].name, size: stackedSize.0)
+        PBAvatar(image: users[0].image, name: users[0].name, size: stackedSize.0, isActive: isActive)
         if users.count == 2 {
-          PBAvatar(image: users[1].image, name: users[1].name, size: stackedSize.1, wrapped: true)
+          PBAvatar(image: users[1].image, name: users[1].name, size: stackedSize.1, wrapped: true, isActive: isActive)
             .offset(x: offsetSize, y: offsetSize)
         } else {
           PBMultipleUsersIndicator(usersCount: users.count - 1, size: stackedSize.1)

--- a/Sources/Playbook/Components/User/Multiple Users Stacked/PBMultipleUsersStacked.swift
+++ b/Sources/Playbook/Components/User/Multiple Users Stacked/PBMultipleUsersStacked.swift
@@ -27,7 +27,7 @@ public struct PBMultipleUsersStacked: View {
       ZStack {
         PBAvatar(image: users[0].image, name: users[0].name, size: stackedSize.0, isActive: users[0].isActive)
         if users.count == 2 {
-          PBAvatar(image: users[1].image, name: users[1].name, size: stackedSize.1, wrapped: true, isActive: users[0].isActive)
+          PBAvatar(image: users[1].image, name: users[1].name, size: stackedSize.1, wrapped: true, isActive: users[1].isActive)
             .offset(x: offsetSize, y: offsetSize)
         } else {
           PBMultipleUsersIndicator(usersCount: users.count - 1, size: stackedSize.1)

--- a/Sources/Playbook/Components/User/Multiple Users Stacked/PBMultipleUsersStacked.swift
+++ b/Sources/Playbook/Components/User/Multiple Users Stacked/PBMultipleUsersStacked.swift
@@ -12,25 +12,22 @@ import SwiftUI
 public struct PBMultipleUsersStacked: View {
   var users: [PBUser]
   var size: Size
-  var isActive: Bool
   public init(
     users: [PBUser] = [],
-    size: Size = .small,
-    isActive: Bool = true
+    size: Size = .small
   ) {
     self.users = users
     self.size = size
-    self.isActive = isActive
   }
 
   public var body: some View {
     if users.count == 1 {
-      PBAvatar(image: users[0].image, name: users[0].name, size: avatarSize, isActive: isActive)
+      PBAvatar(image: users[0].image, name: users[0].name, size: avatarSize, isActive: users[0].isActive)
     } else if users.count >= 2 {
       ZStack {
-        PBAvatar(image: users[0].image, name: users[0].name, size: stackedSize.0, isActive: isActive)
+        PBAvatar(image: users[0].image, name: users[0].name, size: stackedSize.0, isActive: users[0].isActive)
         if users.count == 2 {
-          PBAvatar(image: users[1].image, name: users[1].name, size: stackedSize.1, wrapped: true, isActive: isActive)
+          PBAvatar(image: users[1].image, name: users[1].name, size: stackedSize.1, wrapped: true, isActive: users[0].isActive)
             .offset(x: offsetSize, y: offsetSize)
         } else {
           PBMultipleUsersIndicator(usersCount: users.count - 1, size: stackedSize.1)

--- a/Sources/Playbook/Components/User/Multiple Users/PBMultipleUsers.swift
+++ b/Sources/Playbook/Components/User/Multiple Users/PBMultipleUsers.swift
@@ -17,7 +17,6 @@ public struct PBMultipleUsers: View {
   var bubbleSize: BubbleSize
   var bubbleCount: BubbleCount
   var maxDisplayedUsers: Int
-  var isActive: Bool
   @State private var avSize: CGFloat = 20
   @Environment(\.colorScheme) var colorScheme
 
@@ -28,8 +27,7 @@ public struct PBMultipleUsers: View {
     reversed: Bool = false,
     bubbleSize: BubbleSize = .small,
     bubbleCount: BubbleCount = .two,
-    maxDisplayedUsers: Int = 4,
-    isActive: Bool = true
+    maxDisplayedUsers: Int = 4
   ) {
     self.users = users
     self.size = size
@@ -38,7 +36,6 @@ public struct PBMultipleUsers: View {
     self.bubbleSize = bubbleSize
     self.bubbleCount = bubbleCount
     self.maxDisplayedUsers = maxDisplayedUsers
-    self.isActive = isActive
   }
   
   public var body: some View {
@@ -96,7 +93,7 @@ public extension PBMultipleUsers {
           name: filteredUsers.0[index].name,
           size: size,
           wrapped: true,
-          isActive: isActive
+          isActive: filteredUsers.0[index].isActive
         )
         .offset(x: xOffset(index: index), y: 0)
       }
@@ -133,7 +130,7 @@ public extension PBMultipleUsers {
         name: filteredUsers.0[index].name,
         size: .custom(avatarSize),
         wrapped: true,
-        isActive: isActive
+        isActive: filteredUsers.0[index].isActive
       )
       .padding(index <= 1 ? -1 : -4)
       .offset(

--- a/Sources/Playbook/Components/User/Multiple Users/PBMultipleUsers.swift
+++ b/Sources/Playbook/Components/User/Multiple Users/PBMultipleUsers.swift
@@ -17,6 +17,7 @@ public struct PBMultipleUsers: View {
   var bubbleSize: BubbleSize
   var bubbleCount: BubbleCount
   var maxDisplayedUsers: Int
+  var isActive: Bool
   @State private var avSize: CGFloat = 20
   @Environment(\.colorScheme) var colorScheme
 
@@ -27,7 +28,8 @@ public struct PBMultipleUsers: View {
     reversed: Bool = false,
     bubbleSize: BubbleSize = .small,
     bubbleCount: BubbleCount = .two,
-    maxDisplayedUsers: Int = 4
+    maxDisplayedUsers: Int = 4,
+    isActive: Bool = true
   ) {
     self.users = users
     self.size = size
@@ -36,6 +38,7 @@ public struct PBMultipleUsers: View {
     self.bubbleSize = bubbleSize
     self.bubbleCount = bubbleCount
     self.maxDisplayedUsers = maxDisplayedUsers
+    self.isActive = isActive
   }
   
   public var body: some View {
@@ -92,7 +95,8 @@ public extension PBMultipleUsers {
           image: filteredUsers.0[index].image,
           name: filteredUsers.0[index].name,
           size: size,
-          wrapped: true
+          wrapped: true,
+          isActive: isActive
         )
         .offset(x: xOffset(index: index), y: 0)
       }
@@ -128,7 +132,8 @@ public extension PBMultipleUsers {
         image: filteredUsers.0[index].image,
         name: filteredUsers.0[index].name,
         size: .custom(avatarSize),
-        wrapped: true
+        wrapped: true,
+        isActive: isActive
       )
       .padding(index <= 1 ? -1 : -4)
       .offset(

--- a/Sources/Playbook/Components/User/PBUser.swift
+++ b/Sources/Playbook/Components/User/PBUser.swift
@@ -21,7 +21,8 @@ public struct PBUser: View {
     public var status: PBOnlineStatus.Status?
     public var displayAvatar: Bool = true
     public var territoryTitleFont: PBFont
-    public var hasInActiveBadge: Bool
+    public var isActive: Bool
+
     public init(
         name: String = "",
         nameFont: Typography = .init(font: .title4, variant: .bold),
@@ -34,7 +35,7 @@ public struct PBUser: View {
         status: PBOnlineStatus.Status? = nil,
         displayAvatar: Bool = true,
         territoryTitleFont: PBFont = .subcaption,
-        hasInActiveBadge: Bool = false
+        isActive: Bool = true
     ) {
         self.name = name
         self.nameFont = nameFont
@@ -47,7 +48,7 @@ public struct PBUser: View {
         self.status = status
         self.displayAvatar = displayAvatar
         self.territoryTitleFont = territoryTitleFont
-        self.hasInActiveBadge = hasInActiveBadge
+        self.isActive = isActive
     }
     
     public var body: some View {
@@ -83,16 +84,15 @@ public extension PBUser {
     }
     
     var avatarView: some View {
-        PBAvatar(image: image, name: name, size: size.avatarSize, status: status)
+      PBAvatar(image: image, name: name, size: size.avatarSize, status: status, isActive: isActive)
     }
     
     var contentView: some View {
         VStack(alignment: alignment, spacing: Spacing.none) {
           HStack {
             Text(name)
-              .pbFont(nameFont.font, variant: nameFont.variant)
-              .foregroundColor(.text(.default))
-            if hasInActiveBadge == true {
+              .pbFont(nameFont.font, variant: nameFont.variant, color: isActive ? .text(.default) : .text(.light))
+            if !isActive {
               PBBadge(text: "Inactive", variant: .neutral)
             }
           }

--- a/Sources/Playbook/Components/User/PBUser.swift
+++ b/Sources/Playbook/Components/User/PBUser.swift
@@ -22,7 +22,7 @@ public struct PBUser: View {
     public var displayAvatar: Bool = true
     public var territoryTitleFont: PBFont
     public var isActive: Bool
-
+    public var hasInactiveBadge: Bool
     public init(
         name: String = "",
         nameFont: Typography = .init(font: .title4, variant: .bold),
@@ -35,7 +35,8 @@ public struct PBUser: View {
         status: PBOnlineStatus.Status? = nil,
         displayAvatar: Bool = true,
         territoryTitleFont: PBFont = .subcaption,
-        isActive: Bool = true
+        isActive: Bool = true,
+        hasInactiveBadge: Bool = false
     ) {
         self.name = name
         self.nameFont = nameFont
@@ -49,6 +50,7 @@ public struct PBUser: View {
         self.displayAvatar = displayAvatar
         self.territoryTitleFont = territoryTitleFont
         self.isActive = isActive
+        self.hasInactiveBadge = hasInactiveBadge
     }
     
     public var body: some View {
@@ -92,7 +94,7 @@ public extension PBUser {
           HStack {
             Text(name)
               .pbFont(nameFont.font, variant: nameFont.variant, color: isActive ? .text(.default) : .text(.light))
-            if !isActive {
+            if hasInactiveBadge {
               PBBadge(text: "Inactive", variant: .neutral)
             }
           }


### PR DESCRIPTION
**What does this PR do?** 

[RANGR-1025] Enable Kits to Allow Inactive User

https://runway.powerhrg.com/backlog_items/RANGR-1025

**Notes:** 

Updated Components:

PBUser -> Name font & Avatar. Removed hasInactivebadge and just used isActive to avoid redundant code.
PBMultipleUserStacked -> Added inactive but because we are using mock data and not fetching it, they will all be inactive in Showcase.
PBMultipleUsers -> Added inactive but because we are using mock data and not fetching it, they will all be inactive in Showcase.
PBMessage -> Name font & Avatar. This uses anyview for an avatar so couldn’t enable inactive avatar variant but its ok because it can easily be handled in connect.


### Checklist
- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [x] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [x] **TESTING** - Have you tested your story?
