### PR TITLE
PBMessage avoid hover state change unnecessarily

### DIFF
--- a/Sources/Playbook/Components/Message/PBMessage.swift
+++ b/Sources/Playbook/Components/Message/PBMessage.swift
@@ -111,6 +111,7 @@ public struct PBMessage<Content: View>: View {
       }
       #if os(macOS)
       .onHover { hover in
+        guard changeTimeStampOnHover else { return } 
         isHovering = hover
       }
       #endif


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

I noticed that when the hover state variable got set it caused a refresh of the view which jagged scroll a bit, so since most times we actually have `changeTimeStampOnHover=false` anyway, we don't even need to update `isHovering`. This makes scroll better on Connect.

**Screenshots:** Screenshots to visualize your addition/change

No visual change

**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change

### Checklist
- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
