### PR TITLE
[ROGUE-1511] Edit PBToast action view

### DIFF
--- a/PlaybookShowcase/PlaybookShowcase/Components/Fixed Confirmation Toast/ToastCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/Fixed Confirmation Toast/ToastCatalog.swift
@@ -147,7 +147,7 @@ public struct ToastCatalog: View {
         content: {
           AnyView(
             VStack {
-              Text("Coversation full.")
+              Text("Conversation full.")
                 .pbFont(.title4, color: .white)
               Text("For 10+ members please create a room")
                 .pbFont(.detail(true), color: .white)
@@ -173,6 +173,13 @@ public struct ToastCatalog: View {
               PBButton(variant: .primary, title: "Undo").disabled(true)
             }
           )),
+        dismissAction: closeToast
+      )
+      
+      PBToast(
+        text: "Text with a button link",
+        variant: .error,
+        actionView: .link("Retry"),
         dismissAction: closeToast
       )
     }

--- a/Sources/Playbook/Components/Fixed Confirmation Toast/PBToast.swift
+++ b/Sources/Playbook/Components/Fixed Confirmation Toast/PBToast.swift
@@ -106,7 +106,9 @@ public struct PBToast: View {
         view.onTapGesture {
           dismissAction()
         }
-#if os(iOS)
+#if os(macOS)
+        .padding(.trailing, self.isLink ? Spacing.small : 0)
+#else
         .padding(.top, self.isLink ? -Spacing.xSmall : 0)
 #endif
       }

--- a/Sources/Playbook/Components/Fixed Confirmation Toast/PBToast.swift
+++ b/Sources/Playbook/Components/Fixed Confirmation Toast/PBToast.swift
@@ -95,7 +95,7 @@ public struct PBToast: View {
 #if os(iOS)
           .padding(.horizontal, Spacing.medium)
 #else
-          .padding(self.isLink ? .trailing : .horizontal, self.isLink ? 0 : Spacing.medium)
+          .padding(self.isLink ? .leading : .horizontal, Spacing.medium)
 #endif
       }
       if let content = content {

--- a/Sources/Playbook/Components/Fixed Confirmation Toast/PBToast.swift
+++ b/Sources/Playbook/Components/Fixed Confirmation Toast/PBToast.swift
@@ -34,7 +34,15 @@ public struct PBToast: View {
     self.dismissAction = dismissAction
     self.content = content
   }
-
+  
+  private var isLink: Bool {
+    if let actionView, case .link = actionView {
+      return true
+    } else {
+      return false
+    }
+  }
+  
   public var body: some View {
     HStack {
       if let animatedIcon {
@@ -42,20 +50,23 @@ public struct PBToast: View {
       } else if let icon = variant.icon {
         PBIcon.fontAwesome(icon, size: .x1)
       }
-      if let text = text {
-        Text(text)
-          .pbFont(font, color: .white)
-          .padding(.horizontal, Spacing.medium)
-      }
-      if let content = content {
-        content()
-      }
-      if let dismiss = actionView, let view = dismiss.view {
-        view.onTapGesture {
-          dismissAction()
-        }
-      }
       
+#if os(iOS)
+      if let actionView {
+        switch actionView {
+        case .link:
+          VStack {
+            textContent
+          }
+        default:
+          textContent
+        }
+      } else {
+        textContent
+      }
+#else
+      textContent
+#endif
     }
     .onAppear {
       if let dismiss = actionView {
@@ -74,6 +85,33 @@ public struct PBToast: View {
     )
     .pbShadow(.deeper)
   }
+  
+  @ViewBuilder
+  private var textContent: some View {
+    Group {
+      if let text = text {
+        Text(text)
+          .pbFont(font, color: .white)
+#if os(iOS)
+          .padding(.horizontal, Spacing.medium)
+#else
+          .padding(self.isLink ? .trailing : .horizontal, self.isLink ? 0 : Spacing.medium)
+#endif
+      }
+      if let content = content {
+        content()
+      }
+      
+      if let dismiss = actionView, let view = dismiss.view {
+        view.onTapGesture {
+          dismissAction()
+        }
+#if os(iOS)
+        .padding(.top, self.isLink ? -Spacing.xSmall : 0)
+#endif
+      }
+    }
+  }
 }
 
 public extension PBToast {
@@ -87,19 +125,25 @@ public extension PBToast {
       }
     }
   }
-
+  
   enum DismissAction {
-    case `default`, custom(AnyView), withTimer(TimeInterval)
-
+    case `default`, custom(AnyView), withTimer(TimeInterval), link(String)
+    
     var view: AnyView? {
       switch self {
       case .default: return AnyView(PBIcon.fontAwesome(.times))
       case .custom(let view): return view
       case .withTimer: return nil
+      case .link(let text): return AnyView(
+        Text(text)
+          .underline()
+          .pbFont(.title4, color: .white)
+          .padding(.leading, -Spacing.xxSmall)
+      )
       }
     }
   }
-
+  
   enum Variant {
     case error, success, neutral, tip(FontAwesome? = .infoCircle), custom(FontAwesome? = nil, Color)
     func color(_ custom: Color = .pbPrimary) -> any ShapeStyle   {


### PR DESCRIPTION
**What does this PR do?**

The PR is supposed to create a new variant for actionView, with a text button to be clicked with some action on PBToast.
Also, that edits the position of some items on PBToast as well, according to the OS.

Task on Runway: [ROGUE-1511](https://runway.powerhrg.com/backlog_items/ROGUE-1511)

The component should match the [Handoff](https://huddle.powerapp.cloud/projects/590/handoffs/1527)

**Screenshots:** 

iOS
<img width="363" height="223" alt="pbtoast_ios" src="https://github.com/user-attachments/assets/3504a2dc-baf4-447b-9d05-c2b72a9f1c8c" />

macOS
<img width="388" height="126" alt="pbtoast_macos" src="https://github.com/user-attachments/assets/884310e8-645b-4825-9ae2-2347065574b5" />