### PR TITLE
[ROGUE-2534] update dialog to have a custom icon

### DIFF
--- a/PlaybookShowcase/PlaybookShowcase/Components/Dialog/DialogCatalog.swift
+++ b/PlaybookShowcase/PlaybookShowcase/Components/Dialog/DialogCatalog.swift
@@ -141,14 +141,14 @@ extension DialogCatalog {
 
   var statusView: some View {
     VStack(alignment: .leading, spacing: Spacing.small) {
-      ForEach(Status.allCases, id: \.self) { status in
-        PBButton(title: status.rawValue.capitalized) {
+        ForEach(Status.allCases + [.custom(FontAwesome.folder, .status(.warning))], id: \.id) { status in
+        PBButton(title: status.title.capitalized) {
           DialogCatalog.disableAnimation()
           presentDialogStatus = status
         }
         .presentationMode(item: $presentDialogStatus) { item in
           PBDialog(
-            title: item.rawValue.capitalized,
+            title: item.title.capitalized,
             message: DialogCatalog.infoMessage,
             variant: .status(item),
             isStacked: false,

--- a/Sources/Playbook/Components/Dialog/PBDialog.swift
+++ b/Sources/Playbook/Components/Dialog/PBDialog.swift
@@ -143,7 +143,7 @@ public enum DialogSize: String, CaseIterable, Identifiable {
   }
 }
 
-public enum DialogVariant: Equatable {
+public enum DialogVariant {
     case `default`
     case status(_ status: Status)
     

--- a/Sources/Playbook/Components/Dialog/PBStatusDialogView.swift
+++ b/Sources/Playbook/Components/Dialog/PBStatusDialogView.swift
@@ -47,7 +47,7 @@ public enum Status: Identifiable, CaseIterable {
     [.default, .caution, .delete, .information, .error, .success]
   }
 
-  var title: String {
+  public var title: String {
     switch self {
     case .default: return "Default"
     case .caution: return "Caution"

--- a/Sources/Playbook/Components/Dialog/PBStatusDialogView.swift
+++ b/Sources/Playbook/Components/Dialog/PBStatusDialogView.swift
@@ -59,7 +59,7 @@ public enum Status: Identifiable, CaseIterable {
     }
   }
 
-  var icon: (PlaybookGenericIcon, Color) {
+  public var icon: (PlaybookGenericIcon, Color) {
     switch self {
     case .default: return (FontAwesome.exclamationCircle, .status(.neutral))
     case .caution: return (FontAwesome.exclamationTriangle, .status(.warning))

--- a/Sources/Playbook/Components/Dialog/PBStatusDialogView.swift
+++ b/Sources/Playbook/Components/Dialog/PBStatusDialogView.swift
@@ -31,10 +31,34 @@ struct PBStatusDialogView: View {
     .padding()
   }
 }
-public enum Status: String, CaseIterable, Identifiable {
-  public var id: UUID { UUID() }
 
-  case `default`, caution, delete, information, error, success
+public enum Status: Identifiable, CaseIterable {
+  public var id: String { title }
+
+  case `default`
+  case caution
+  case delete
+  case information
+  case error
+  case success
+  case custom(PlaybookGenericIcon, Color)
+
+  public static var allCases: [Status] {
+    [.default, .caution, .delete, .information, .error, .success]
+  }
+
+  var title: String {
+    switch self {
+    case .default: return "Default"
+    case .caution: return "Caution"
+    case .delete: return "Delete"
+    case .information: return "Information"
+    case .error: return "Error"
+    case .success: return "Success"
+    case .custom: return "Custom"
+    }
+  }
+
   var icon: (PlaybookGenericIcon, Color) {
     switch self {
     case .default: return (FontAwesome.exclamationCircle, .status(.neutral))
@@ -43,17 +67,18 @@ public enum Status: String, CaseIterable, Identifiable {
     case .information: return (FontAwesome.infoCircle, .status(.neutral))
     case .error: return (FontAwesome.timesCircle, .status(.error))
     case .success: return (FontAwesome.checkCircle, .status(.success))
+    case .custom(let icon, let color): return (icon, color)
     }
   }
 }
 
 #Preview {
   registerFonts()
-  return List(Status.allCases, id: \.self) { status in
+    return List(Status.allCases + [.custom(FontAwesome.folder, .status(.warning))], id: \.id) { status in
     Section {
       PBStatusDialogView(
         status: status,
-        title: status.rawValue.capitalized,
+        title: status.title,
         description: "Some description Some description Some description Some description Some description"
       )
       .frame(maxWidth: .infinity)


### PR DESCRIPTION
**What does this PR do?** This PR updates `PBDialog` to enable custom icon and coloring.

Task on Runway [ROGUE-2534](https://nitro.powerhrg.com/runway/backlog_items/ROGUE-2534).

**Screenshots:** Screenshots to visualize your addition/change

<img width="390" height="318" alt="image" src="https://github.com/user-attachments/assets/aab5ce58-3df0-48db-9d78-766586560c96" />


**How to test?** Steps to confirm the desired behavior:
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See addition/change

### Checklist
- [x] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [x] **TESTING** - Have you tested your story?
