### PR TITLE
[ROGUE-2653] typeahead: scrollable pills

### DIFF
--- a/Sources/Playbook/Components/Typeahead/GridInputField.swift
+++ b/Sources/Playbook/Components/Typeahead/GridInputField.swift
@@ -12,22 +12,26 @@ import SwiftUI
 public struct GridInputField: View {
   private let placeholder: String
   private let selection: Selection
+  private let selectedOptionsMaxHeight: CGFloat
   private let clearAction: (() -> Void)?
   private let onItemTap: ((Int) -> Void)?
   private let onViewTap: (() -> Void)?
   private let onDelete: (() -> Void)?
   private let shape = RoundedRectangle(cornerRadius: BorderRadius.medium)
+  private let inputFieldID = "grid-input-field-text-field"
   private var isFocused: FocusState<Bool>.Binding
   @Binding var searchText: String
   @State private var isHovering: Bool = false
   @State private var clearButtonIsHovering: Bool = false
   @State private var indicatorIsHovering: Bool = false
   @State private var textFrame: CGRect = .zero
+  @State private var selectedOptionsGridHeight: CGFloat = 40
 
   init(
     placeholder: String = "Select",
     searchText: Binding<String>,
     selection: Selection,
+    selectedOptionsMaxHeight: CGFloat = 220,
     isFocused: FocusState<Bool>.Binding,
     clearAction: (() -> Void)? = nil,
     onItemTap: ((Int) -> Void)? = nil,
@@ -37,6 +41,7 @@ public struct GridInputField: View {
     self.placeholder = placeholder
     self._searchText = searchText
     self.selection = selection
+    self.selectedOptionsMaxHeight = selectedOptionsMaxHeight
     self.isFocused = isFocused
     self.clearAction = clearAction
     self.onItemTap = onItemTap
@@ -47,22 +52,8 @@ public struct GridInputField: View {
   public var body: some View {
     VStack(alignment: .leading) {
       HStack {
-        PBGrid(
-          alignment: .leading,
-          horizontalSpacing: Spacing.xSmall,
-          verticalSpacing: Spacing.xSmall,
-          fitContent: false
-        ) {
-          ForEach(indices, id: \.self) { index in
-            if indices.last != index {
-              gridView(index: index)
-            }
-          }
-          textfieldWithCustomPlaceholder
-        }
-        .padding(.horizontal, Spacing.small)
-        .padding(.vertical, Spacing.xSmall)
-        .frameReader { textFrame = $0 }
+        selectedOptionsContainer
+          .frame(maxWidth: .infinity, alignment: .leading)
         dismissIconView
         indicatorView
       }
@@ -85,10 +76,56 @@ public struct GridInputField: View {
 }
 
 private extension GridInputField {
+  var selectedOptionsContainer: some View {
+    ScrollViewReader { proxy in
+      ScrollView(.vertical, showsIndicators: false) {
+        selectedOptionsGrid
+          .sizeReader { size in
+            selectedOptionsGridHeight = max(size.height, 40)
+          }
+      }
+      .frame(height: min(selectedOptionsGridHeight, selectedOptionsMaxHeight))
+      .onAppear {
+        scrollToInput(proxy)
+      }
+      .onChange(of: selectedOptionsCount) {
+        scrollToInput(proxy)
+      }
+    }
+  }
+
+  var selectedOptionsGrid: some View {
+    PBGrid(
+      alignment: .leading,
+      horizontalSpacing: Spacing.xSmall,
+      verticalSpacing: Spacing.xSmall,
+      fitContent: false
+    ) {
+      ForEach(indices, id: \.self) { index in
+        if indices.last != index {
+          gridView(index: index)
+        }
+      }
+      textfieldWithCustomPlaceholder
+        .id(inputFieldID)
+    }
+    .padding(.horizontal, Spacing.small)
+    .padding(.vertical, Spacing.xSmall)
+    .frameReader { textFrame = $0 }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
   var indices: Range<Int> {
     switch selection {
       case .multiple(_, let options): return Range(0...(options?.count ?? 0))
       case .single(_): return Range(0...1)
+    }
+  }
+
+  var selectedOptionsCount: Int {
+    switch selection {
+      case .multiple(_, let options): return options?.count ?? 0
+      case .single(let option): return option == nil ? 0 : 1
     }
   }
 
@@ -225,6 +262,12 @@ private extension GridInputField {
       return Color.text(.default)
     } else {
       return Color.text(.lighter)
+    }
+  }
+
+  func scrollToInput(_ proxy: ScrollViewProxy) {
+    DispatchQueue.main.async {
+      proxy.scrollTo(inputFieldID, anchor: .bottom)
     }
   }
 }

--- a/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
@@ -41,6 +41,7 @@ public extension PBTypeahead {
       ZStack {
         if viewModel.showDropdown {
           listView
+            .zIndex(1_000)
         }
       }
     }
@@ -74,6 +75,7 @@ public extension PBTypeahead {
       }
     }
     .frame(maxWidth: dropdownWidth)
+    .zIndex(1_000)
   }
 
   func listItemView(option: PBTypeahead.Option, index: Int) -> some View {

--- a/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead+View.swift
@@ -21,6 +21,7 @@ public extension PBTypeahead {
       placeholder: placeholder,
       searchText: $searchText,
       selection: selectedInputOptions,
+      selectedOptionsMaxHeight: selectedOptionsMaxHeight,
       isFocused: $isFocused,
       clearAction: { viewModel.clear() },
       onItemTap: { viewModel.removeSelected($0) },

--- a/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
@@ -21,6 +21,7 @@ public struct PBTypeahead: View {
   internal let debounce: (time: TimeInterval, numberOfCharacters: Int)
   internal let disableFiltering: Bool
   internal let disableKeyboardHandler: Bool
+  internal let selectedOptionsMaxHeight: CGFloat
 
   @State internal var selectedInputOptions: GridInputField.Selection
   @State var dropdownHeight: CGFloat = 48
@@ -46,6 +47,7 @@ public struct PBTypeahead: View {
     selection: PBTypeahead.Selection,
     debounce: (time: TimeInterval, numberOfCharacters: Int) = (0, 0),
     dropdownMaxHeight: CGFloat? = nil,
+    selectedOptionsMaxHeight: CGFloat = 220,
     isFocused: FocusState<Bool>.Binding,
     selectedOptions: Binding<[PBTypeahead.Option]>,
     deselectedOptions: Binding<[PBTypeahead.Option]> = .constant([]),
@@ -65,6 +67,7 @@ public struct PBTypeahead: View {
     self.selection = selection
     self.debounce = debounce
     self.dropdownMaxHeight = dropdownMaxHeight
+    self.selectedOptionsMaxHeight = selectedOptionsMaxHeight
     self._isFocused = isFocused
     self.clearAction = clearAction
     self._selectedOptions = selectedOptions

--- a/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
+++ b/Sources/Playbook/Components/Typeahead/PBTypeahead.swift
@@ -152,6 +152,7 @@ public struct PBTypeahead: View {
         placeholder: placeholder
       )
     }
+    .zIndex(viewModel.showDropdown ? 1_000 : 0)
   }
 }
 


### PR DESCRIPTION
**What does this PR do?** A clear and concise description with your runway ticket url.

Working on https://runway.powerhrg.com/backlog_items/ROGUE-2653 we realized the pills container was getting too long and we wanted it to scroll after a certain size. I copied the component to our repo and made the necessary changes, now I'm proposing we merge them to playbook.

Task on Runway -- no task yet

- Adds a `selectedOptionsMaxHeight` option to `PBTypeahead` with a default of `220` -- if you wanna change this let me know
- Updates `GridInputField` so selected pill options render inside a capped vertical scroll area.
- Keeps the text input scrolled into view as selected options are added or removed.
- Preserves the dropdown stacking fixes so the open typeahead renders above neighboring content.

**Screenshots:** Screenshots to visualize your addition/change



**How to test?** Steps to confirm the desired behavior:
1. visual test, check if pills list scrolls

### Checklist
- [ ] **LABELS** - Add a label: `breaking`, `bug`, `improvement`, `documentation`, or `enhancement`. See [Labels](https://github.com/powerhome/playbook-apple/labels) for descriptions.
- [ ] **RELEASES** - Add the appropriate label: `Ready for Testing` / `Ready for Release`
- [ ] **TESTING** - Have you tested your story?
